### PR TITLE
662: Add isolation strategies and preload configuration options

### DIFF
--- a/docs/isolation.md
+++ b/docs/isolation.md
@@ -1,0 +1,114 @@
+# Isolation strategies
+
+Evilution runs every mutant inside an isolated environment so a misbehaving
+mutant cannot corrupt the runner's state or the surrounding test suite. The
+`--isolation` flag (and the `isolation:` config key) selects which strategy
+is used.
+
+## Strategies
+
+| Strategy     | What it does                                                           | When to use                                                |
+| ------------ | ---------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `auto`       | Default. Picks `fork` for Rails projects, `in_process` otherwise.      | Leave this on unless you have a specific reason to change. |
+| `fork`       | Forks a fresh child process per mutant. Parent `SIGKILL`s on timeout.  | Rails / ActiveRecord projects; any code that uses mutexes, monitors, or async-interrupt masks. |
+| `in_process` | Runs the mutant inside the runner process under `Timeout.timeout`.     | Pure-Ruby libraries that do not use async-interrupt masks. |
+
+## Why fork is the default for Rails projects
+
+Rails wraps every ActiveRecord transaction in
+`Thread.handle_interrupt(Exception => :never)` to guarantee that a transaction
+either commits cleanly or rolls back cleanly — it must never exit the
+transaction block with a half-delivered exception. The mask is
+[load-bearing for transaction correctness][rails-handle-interrupt].
+
+That mask interacts badly with `Timeout.timeout`. The Timeout gem schedules a
+timer thread which fires `Thread#raise Timeout::Error` at the main thread when
+the deadline hits. Ruby receives the `raise`, inspects the interrupt mask, sees
+`Exception => :never`, and **queues the exception for later delivery** — "later"
+meaning "when the masked block exits". If the mutant is stuck in an infinite
+loop inside the transaction, the block never exits, the queued exception is
+never delivered, and the runner hangs indefinitely.
+
+This is not a bug in Timeout or in Rails. Each component is correct in
+isolation. They simply do not compose for in-process timeout-based
+cancellation. The only primitive that can escape a masked-interrupt section
+in the same thread is an out-of-band kernel signal — `SIGKILL` from another
+process. That is exactly what the `fork` strategy provides.
+
+Because of this, `auto` resolves to `fork` whenever the target files live
+under a detected Rails root (i.e. a directory containing
+`config/application.rb`). If you explicitly pass `--isolation in_process` on
+a Rails project, evilution emits a warning naming the hazard and proceeds
+anyway — sometimes you know the code under test never enters a masked
+section, and that is your call to make.
+
+The same hazard applies to any Ruby code that uses
+`Thread.handle_interrupt(... => :never)`: `Mutex#synchronize`, `Monitor#synchronize`,
+`Queue`, `ActiveSupport::Notifications::Fanout` listeners, and custom cleanup
+blocks that wrap "must complete" sections. If your target code can touch any
+of those, prefer `--isolation fork`.
+
+## Parent-process preload
+
+Fork isolation's one downside is that every child pays the cost of loading
+its test framework from scratch. For a Rails app, that is 5–15 seconds of
+`require "rails/all"` per mutant — multiplied by hundreds of mutants, the
+run takes hours.
+
+To avoid that cost, evilution preloads a bootstrap file in the **parent**
+process before the mutation loop begins. Once Rails is loaded in the parent,
+every forked child inherits the loaded state via copy-on-write, and the child
+runs its test near-instantly against an already-loaded framework.
+
+### Automatic preload
+
+For Rails projects (auto-detected via `config/application.rb`), evilution
+automatically looks for these files in order and preloads the first one it
+finds:
+
+1. `spec/rails_helper.rb` (RSpec)
+2. `test/test_helper.rb` (Minitest)
+
+No configuration needed.
+
+### Explicit preload
+
+Override the auto-detected path with the `--preload` flag or the `preload:`
+config key:
+
+```bash
+bundle exec evilution run app/models/user.rb --preload config/evilution_boot.rb
+```
+
+```yaml
+# .evilution.yml
+preload: config/evilution_boot.rb
+```
+
+The path is resolved relative to the working directory. Preload failures
+(the file does not exist, or it raises during `require`) are fatal —
+evilution aborts with an `Evilution::ConfigError` that includes the original
+exception.
+
+### Disabling preload
+
+Pass `--no-preload` on the CLI or set `preload: false` in `.evilution.yml`:
+
+```bash
+bundle exec evilution run app/models/user.rb --no-preload
+```
+
+The MCP tool (`evilution-mutate`) disables preload unconditionally, because
+the MCP server is a long-lived process that handles runs from different
+projects — preloading one project's Rails stack into a shared process would
+poison subsequent runs.
+
+## Related flags
+
+- `--timeout N` sets the per-mutation time limit. Under `fork`, this drives
+  SIGKILL. Under `in_process`, this drives `Timeout.timeout` and is subject
+  to the interrupt-mask hazard described above.
+- `--jobs N` runs N workers in parallel. Note: the parallel pool currently
+  uses in-process isolation inside its workers — see issue #663.
+
+[rails-handle-interrupt]: https://github.com/rails/rails/blob/main/activesupport/lib/active_support/concurrency/thread_monitor.rb

--- a/lib/evilution/cli.rb
+++ b/lib/evilution/cli.rb
@@ -249,6 +249,9 @@ class Evilution::CLI
     opts.on("--incremental", "Cache killed/timeout results; skip re-running them on unchanged files") { @options[:incremental] = true }
     opts.on("--integration NAME", "Test integration: rspec, minitest (default: rspec)") { |i| @options[:integration] = i }
     opts.on("--isolation STRATEGY", "Isolation: auto, fork, in_process (default: auto)") { |s| @options[:isolation] = s }
+    opts.on("--preload FILE", "Preload FILE in the parent process before forking " \
+                              "(default: auto-detect spec/rails_helper.rb for Rails projects)") { |f| @options[:preload] = f }
+    opts.on("--no-preload", "Disable parent-process preload even for Rails projects") { @options[:preload] = false }
     opts.on("--stdin", "Read target file paths from stdin (one per line)") { @options[:stdin] = true }
     opts.on("--suggest-tests", "Generate concrete test code in suggestions (RSpec or Minitest)") { @options[:suggest_tests] = true }
     opts.on("--no-progress", "Disable progress bar") { @options[:progress] = false }

--- a/lib/evilution/config.rb
+++ b/lib/evilution/config.rb
@@ -142,9 +142,9 @@ class Evilution::Config
       # skip_heredoc_literals: false
 
       # Preload file required in the parent process before forking workers.
-      # For Rails projects, spec/rails_helper.rb is auto-detected when
-      # isolation resolves to :fork. Set to false to disable.
-      # preload: spec/rails_helper.rb
+      # For Rails projects, spec/rails_helper.rb or test/test_helper.rb is
+      # auto-detected when isolation resolves to :fork. Set to false to disable.
+      # preload: spec/rails_helper.rb # or test/test_helper.rb
 
       # Hooks: Ruby files returning a Proc, keyed by lifecycle event
       # hooks:

--- a/lib/evilution/config.rb
+++ b/lib/evilution/config.rb
@@ -26,7 +26,8 @@ class Evilution::Config
     ignore_patterns: [],
     show_disabled: false,
     baseline_session: nil,
-    skip_heredoc_literals: false
+    skip_heredoc_literals: false,
+    preload: nil
   }.freeze
 
   attr_reader :target_files, :timeout, :format,
@@ -34,7 +35,7 @@ class Evilution::Config
               :jobs, :fail_fast, :baseline, :isolation, :incremental, :suggest_tests,
               :progress, :save_session, :line_ranges, :spec_files, :hooks,
               :ignore_patterns, :show_disabled, :baseline_session,
-              :skip_heredoc_literals
+              :skip_heredoc_literals, :preload
 
   def initialize(**options)
     file_options = options.delete(:skip_config_file) ? {} : load_config_file
@@ -140,6 +141,11 @@ class Evilution::Config
       # Skip all string literal mutations inside heredocs (default: false)
       # skip_heredoc_literals: false
 
+      # Preload file required in the parent process before forking workers.
+      # For Rails projects, spec/rails_helper.rb is auto-detected when
+      # isolation resolves to :fork. Set to false to disable.
+      # preload: spec/rails_helper.rb
+
       # Hooks: Ruby files returning a Proc, keyed by lifecycle event
       # hooks:
       #   worker_process_start: config/evilution_hooks/worker_start.rb
@@ -190,6 +196,15 @@ class Evilution::Config
     @baseline_session = merged[:baseline_session]
     @skip_heredoc_literals = merged[:skip_heredoc_literals]
     @hooks = validate_hooks(merged[:hooks])
+    @preload = validate_preload(merged[:preload])
+  end
+
+  def validate_preload(value)
+    return nil if value.nil?
+    return false if value == false
+    return value if value.is_a?(String)
+
+    raise Evilution::ConfigError, "preload must be nil, false, or a String path, got #{value.inspect}"
   end
 
   def validate_integration(value)

--- a/lib/evilution/mcp/mutate_tool.rb
+++ b/lib/evilution/mcp/mutate_tool.rb
@@ -111,7 +111,11 @@ class Evilution::MCP::MutateTool < MCP::Tool
     end
 
     def build_config_opts(files, line_ranges, target, timeout, jobs, fail_fast, spec, suggest_tests)
-      opts = { target_files: files, line_ranges: line_ranges, format: :json, quiet: true, skip_config_file: true }
+      # Preload is disabled for MCP invocations: `require`-ing Rails into the
+      # long-lived MCP server would poison subsequent runs against other
+      # projects. MCP users who want the speedup should use the CLI.
+      opts = { target_files: files, line_ranges: line_ranges, format: :json, quiet: true, skip_config_file: true,
+               preload: false }
       opts[:target] = target if target
       opts[:timeout] = timeout if timeout
       opts[:jobs] = jobs if jobs

--- a/lib/evilution/rails_detector.rb
+++ b/lib/evilution/rails_detector.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Evilution::RailsDetector
+  MARKER = File.join("config", "application.rb").freeze
+
+  @cache = {}
+  @mutex = Mutex.new
+
+  class << self
+    def rails_root_for(path)
+      return nil if path.nil?
+
+      dir = starting_dir(path)
+      return nil if dir.nil?
+
+      @mutex.synchronize do
+        return @cache[dir] if @cache.key?(dir)
+
+        @cache[dir] = walk_up(dir)
+      end
+    end
+
+    def rails_root_for_any(paths)
+      Array(paths).each do |path|
+        root = rails_root_for(path)
+        return root if root
+      end
+      nil
+    end
+
+    def reset_cache!
+      @mutex.synchronize { @cache.clear }
+    end
+
+    private
+
+    def starting_dir(path)
+      return File.expand_path(path) if File.directory?(path)
+      return File.expand_path(File.dirname(path)) if File.file?(path)
+
+      parent = File.expand_path(File.dirname(path))
+      File.directory?(parent) ? parent : nil
+    end
+
+    def walk_up(dir)
+      current = dir
+      loop do
+        return current if File.file?(File.join(current, MARKER))
+
+        parent = File.dirname(current)
+        return nil if parent == current
+
+        current = parent
+      end
+    end
+  end
+end

--- a/lib/evilution/runner.rb
+++ b/lib/evilution/runner.rb
@@ -46,7 +46,6 @@ class Evilution::Runner
     @hooks = hooks
     @parser = Evilution::AST::Parser.new
     @registry = Evilution::Mutator::Registry.default
-    @isolator = build_isolator
     @cache = config.incremental? ? Evilution::Cache.new : nil
     @disable_detector = Evilution::DisableComment.new
     @disabled_ranges_cache = {}
@@ -98,7 +97,11 @@ class Evilution::Runner
 
   private
 
-  attr_reader :parser, :registry, :isolator, :cache, :on_result, :hooks, :disable_detector, :sig_detector
+  attr_reader :parser, :registry, :cache, :on_result, :hooks, :disable_detector, :sig_detector
+
+  def isolator
+    @isolator ||= build_isolator
+  end
 
   def parse_subjects
     files = resolve_target_files
@@ -106,10 +109,13 @@ class Evilution::Runner
   end
 
   def resolve_target_files
-    return resolve_source_glob if source_glob_target?
-    return config.target_files unless config.target_files.empty?
-
-    Evilution::Git::ChangedFiles.new.call
+    @resolve_target_files ||= if source_glob_target?
+                                resolve_source_glob
+                              elsif !config.target_files.empty?
+                                config.target_files
+                              else
+                                Evilution::Git::ChangedFiles.new.call
+                              end
   end
 
   def source_glob_target?
@@ -512,7 +518,7 @@ class Evilution::Runner
   def detected_rails_root
     return @detected_rails_root if defined?(@detected_rails_root)
 
-    @detected_rails_root = Evilution::RailsDetector.rails_root_for_any(config.target_files)
+    @detected_rails_root = Evilution::RailsDetector.rails_root_for_any(resolve_target_files)
   end
 
   def perform_preload
@@ -523,7 +529,7 @@ class Evilution::Runner
     return unless path
 
     require File.expand_path(path)
-  rescue LoadError, StandardError => e
+  rescue ScriptError, StandardError => e
     raise Evilution::ConfigError.new(
       "failed to preload #{path.inspect}: #{e.class}: #{e.message}",
       file: path

--- a/lib/evilution/runner.rb
+++ b/lib/evilution/runner.rb
@@ -25,12 +25,18 @@ require_relative "ast/pattern/filter"
 require_relative "temp_dir_tracker"
 require_relative "disable_comment"
 require_relative "ast/sorbet_sig_detector"
+require_relative "rails_detector"
 
 class Evilution::Runner
   INTEGRATIONS = {
     rspec: Evilution::Integration::RSpec,
     minitest: Evilution::Integration::Minitest
   }.freeze
+
+  PRELOAD_CANDIDATES = [
+    File.join("spec", "rails_helper.rb"),
+    File.join("test", "test_helper.rb")
+  ].freeze
 
   attr_reader :config
 
@@ -54,6 +60,9 @@ class Evilution::Runner
 
     subjects = parse_and_filter_subjects
     log_memory("after parse_subjects", "#{subjects.length} subjects")
+
+    perform_preload
+    log_memory("after preload") if rails_root_detected?
 
     baseline_result = run_baseline(subjects)
 
@@ -483,9 +492,80 @@ class Evilution::Runner
   end
 
   def resolve_isolation
-    return :fork if config.isolation == :fork
+    case config.isolation
+    when :fork
+      :fork
+    when :in_process
+      warn_in_process_under_rails if rails_root_detected?
+      :in_process
+    else # :auto
+      rails_root_detected? ? :fork : :in_process
+    end
+  end
 
-    :in_process
+  def rails_root_detected?
+    return @rails_root_detected if defined?(@rails_root_detected)
+
+    @rails_root_detected = !detected_rails_root.nil?
+  end
+
+  def detected_rails_root
+    return @detected_rails_root if defined?(@detected_rails_root)
+
+    @detected_rails_root = Evilution::RailsDetector.rails_root_for_any(config.target_files)
+  end
+
+  def perform_preload
+    return if config.preload == false
+    return unless resolve_isolation == :fork
+
+    path = resolve_preload_path
+    return unless path
+
+    require File.expand_path(path)
+  rescue LoadError, StandardError => e
+    raise Evilution::ConfigError.new(
+      "failed to preload #{path.inspect}: #{e.class}: #{e.message}",
+      file: path
+    )
+  end
+
+  def resolve_preload_path
+    if config.preload.is_a?(String)
+      unless File.file?(config.preload)
+        raise Evilution::ConfigError.new(
+          "preload file not found: #{config.preload.inspect}",
+          file: config.preload
+        )
+      end
+      return config.preload
+    end
+
+    root = detected_rails_root
+    return nil unless root
+
+    PRELOAD_CANDIDATES.each do |rel|
+      abs = File.join(root, rel)
+      return abs if File.file?(abs)
+    end
+    nil
+  end
+
+  # When the user explicitly requests InProcess on a Rails project, warn once
+  # per run. Rails wraps ActiveRecord transactions in
+  # Thread.handle_interrupt(Exception => :never), which defers Timeout's
+  # Thread#raise indefinitely — making InProcess unable to kill runaway mutants.
+  def warn_in_process_under_rails
+    return if config.quiet
+    return if @warned_in_process_under_rails
+
+    @warned_in_process_under_rails = true
+    $stderr.write(
+      "[evilution] warning: --isolation in_process is unsafe on Rails projects. " \
+      "ActiveRecord wraps transactions in Thread.handle_interrupt(Exception => :never), " \
+      "which swallows Timeout.timeout and can cause evilution to hang indefinitely on " \
+      "mutants that introduce infinite loops. Use --isolation fork for reliable interruption.\n"
+    )
   end
 
   def resolve_integration_class

--- a/spec/evilution/isolation/fork_spec.rb
+++ b/spec/evilution/isolation/fork_spec.rb
@@ -49,6 +49,27 @@ RSpec.describe Evilution::Isolation::Fork do
       expect(result).to be_timeout
     end
 
+    # Regression for EV-86l6 / GH #662:
+    # Rails wraps ActiveRecord transactions in
+    # Thread.handle_interrupt(Exception => :never), which defers Timeout's
+    # Thread#raise indefinitely. InProcess isolation hangs forever on such
+    # mutants. Fork isolation escapes the mask via SIGKILL from the parent.
+    it "kills a child stuck inside Thread.handle_interrupt(Exception => :never)" do
+      test_command = lambda { |_m|
+        Thread.handle_interrupt(Exception => :never) do
+          loop { 1 + 1 }
+        end
+        { passed: true }
+      }
+
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = isolator.call(mutation: mutation, test_command: test_command, timeout: 0.2)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+
+      expect(result).to be_timeout
+      expect(elapsed).to be < 5 # Fork::GRACE_PERIOD (2s) + margin
+    end
+
     it "cleans up tracked temp dirs after a timeout" do
       dir = Dir.mktmpdir("evilution")
       Evilution::TempDirTracker.register(dir)

--- a/spec/evilution/rails_detector_spec.rb
+++ b/spec/evilution/rails_detector_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fileutils"
+require "tmpdir"
+require "evilution/rails_detector"
+
+RSpec.describe Evilution::RailsDetector do
+  around do |example|
+    Dir.mktmpdir("evilution-rails-detector") do |tmp|
+      @tmp = tmp
+      described_class.reset_cache!
+      example.run
+    end
+  end
+
+  def rails_tree
+    FileUtils.mkdir_p(File.join(@tmp, "config"))
+    FileUtils.mkdir_p(File.join(@tmp, "app", "models"))
+    File.write(File.join(@tmp, "config", "application.rb"), "# Rails app\n")
+    File.write(File.join(@tmp, "app", "models", "user.rb"), "class User; end\n")
+  end
+
+  def non_rails_tree
+    FileUtils.mkdir_p(File.join(@tmp, "lib"))
+    File.write(File.join(@tmp, "lib", "thing.rb"), "class Thing; end\n")
+  end
+
+  describe ".rails_root_for" do
+    it "returns the Rails root when the path lives under one" do
+      rails_tree
+      result = described_class.rails_root_for(File.join(@tmp, "app", "models", "user.rb"))
+      expect(result).to eq(@tmp)
+    end
+
+    it "returns nil when no config/application.rb exists up the tree" do
+      non_rails_tree
+      expect(described_class.rails_root_for(File.join(@tmp, "lib", "thing.rb"))).to be_nil
+    end
+
+    it "returns nil for a non-existent path" do
+      expect(described_class.rails_root_for(File.join(@tmp, "does_not_exist.rb"))).to be_nil
+    end
+
+    it "memoizes the walk-up result for the same directory" do
+      rails_tree
+      path = File.join(@tmp, "app", "models", "user.rb")
+      described_class.rails_root_for(path)
+      # Remove the marker; memoized result should still return
+      FileUtils.rm_f(File.join(@tmp, "config", "application.rb"))
+      expect(described_class.rails_root_for(path)).to eq(@tmp)
+    end
+
+    it "stops at the filesystem root without error" do
+      FileUtils.mkdir_p(File.join(@tmp, "a", "b"))
+      File.write(File.join(@tmp, "a", "b", "x.rb"), "")
+      expect(described_class.rails_root_for(File.join(@tmp, "a", "b", "x.rb"))).to be_nil
+    end
+  end
+
+  describe ".rails_root_for_any" do
+    it "returns the first detected root among a list of paths" do
+      rails_tree
+      described_class.reset_cache!
+      paths = [
+        File.join(@tmp, "nowhere.rb"),
+        File.join(@tmp, "app", "models", "user.rb")
+      ]
+      expect(described_class.rails_root_for_any(paths)).to eq(@tmp)
+    end
+
+    it "returns nil when no path is under a Rails root" do
+      non_rails_tree
+      expect(described_class.rails_root_for_any([File.join(@tmp, "lib", "thing.rb")])).to be_nil
+    end
+
+    it "returns nil for an empty list" do
+      expect(described_class.rails_root_for_any([])).to be_nil
+    end
+  end
+end

--- a/spec/evilution/runner_isolation_spec.rb
+++ b/spec/evilution/runner_isolation_spec.rb
@@ -57,6 +57,15 @@ RSpec.describe Evilution::Runner, "isolation resolution" do
       runner = described_class.new(config: config)
       expect(resolved_isolator_class(runner)).to eq(Evilution::Isolation::InProcess)
     end
+
+    it "detects Rails via resolved files when target_files is empty" do
+      write_rails_target
+      config = build_config(target_files: [])
+      runner = described_class.new(config: config)
+      resolved = [File.join(@tmp, "app", "models", "user.rb")]
+      allow(runner).to receive(:resolve_target_files).and_return(resolved)
+      expect(resolved_isolator_class(runner)).to eq(Evilution::Isolation::Fork)
+    end
   end
 
   describe "with isolation: :fork" do
@@ -87,7 +96,8 @@ RSpec.describe Evilution::Runner, "isolation resolution" do
         target_files: [File.join(@tmp, "app", "models", "user.rb")],
         quiet: false
       )
-      expect { described_class.new(config: config) }.to output(/handle_interrupt|--isolation fork/).to_stderr
+      runner = described_class.new(config: config)
+      expect { resolved_isolator_class(runner) }.to output(/handle_interrupt|--isolation fork/).to_stderr
     end
 
     it "resolves to InProcess on a Rails project when explicitly requested" do
@@ -121,9 +131,9 @@ RSpec.describe Evilution::Runner, "isolation resolution" do
       captured = StringIO.new
       orig = $stderr
       $stderr = captured
-      runner = described_class.new(config: config) # first warn during initialize
+      runner = described_class.new(config: config)
+      runner.send(:build_isolator) # first warn
       runner.send(:build_isolator) # should not warn again
-      runner.send(:build_isolator)
       $stderr = orig
       expect(captured.string.scan("handle_interrupt").length).to eq(1)
     end

--- a/spec/evilution/runner_isolation_spec.rb
+++ b/spec/evilution/runner_isolation_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "evilution/runner"
+require "evilution/rails_detector"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe Evilution::Runner, "isolation resolution" do
+  around do |example|
+    Dir.mktmpdir("evilution-runner-isolation") do |tmp|
+      @tmp = tmp
+      Evilution::RailsDetector.reset_cache!
+      example.run
+    end
+  end
+
+  def build_config(**overrides)
+    Evilution::Config.new(
+      target_files: [File.join(@tmp, "lib", "thing.rb")],
+      format: :json,
+      timeout: 5,
+      quiet: true,
+      baseline: false,
+      isolation: :auto,
+      skip_config_file: true,
+      **overrides
+    )
+  end
+
+  def write_plain_target
+    FileUtils.mkdir_p(File.join(@tmp, "lib"))
+    File.write(File.join(@tmp, "lib", "thing.rb"), "class Thing; end\n")
+  end
+
+  def write_rails_target
+    FileUtils.mkdir_p(File.join(@tmp, "config"))
+    FileUtils.mkdir_p(File.join(@tmp, "app", "models"))
+    File.write(File.join(@tmp, "config", "application.rb"), "# Rails\n")
+    File.write(File.join(@tmp, "app", "models", "user.rb"), "class User; end\n")
+  end
+
+  def resolved_isolator_class(runner)
+    runner.send(:build_isolator).class
+  end
+
+  describe "with isolation: :auto" do
+    it "selects Fork when any target lives under a Rails root" do
+      write_rails_target
+      config = build_config(target_files: [File.join(@tmp, "app", "models", "user.rb")])
+      runner = described_class.new(config: config)
+      expect(resolved_isolator_class(runner)).to eq(Evilution::Isolation::Fork)
+    end
+
+    it "selects InProcess when no target lives under a Rails root" do
+      write_plain_target
+      config = build_config
+      runner = described_class.new(config: config)
+      expect(resolved_isolator_class(runner)).to eq(Evilution::Isolation::InProcess)
+    end
+  end
+
+  describe "with isolation: :fork" do
+    it "always uses Fork regardless of Rails detection" do
+      write_rails_target
+      config = build_config(
+        isolation: :fork,
+        target_files: [File.join(@tmp, "app", "models", "user.rb")]
+      )
+      runner = described_class.new(config: config)
+      expect(resolved_isolator_class(runner)).to eq(Evilution::Isolation::Fork)
+    end
+  end
+
+  describe "with isolation: :in_process" do
+    it "uses InProcess on a non-Rails project without warning" do
+      write_plain_target
+      config = build_config(isolation: :in_process)
+      runner = described_class.new(config: config)
+      expect { resolved_isolator_class(runner) }.not_to output.to_stderr
+      expect(resolved_isolator_class(runner)).to eq(Evilution::Isolation::InProcess)
+    end
+
+    it "still uses InProcess on a Rails project but warns once to stderr" do
+      write_rails_target
+      config = build_config(
+        isolation: :in_process,
+        target_files: [File.join(@tmp, "app", "models", "user.rb")],
+        quiet: false
+      )
+      expect { described_class.new(config: config) }.to output(/handle_interrupt|--isolation fork/).to_stderr
+    end
+
+    it "resolves to InProcess on a Rails project when explicitly requested" do
+      write_rails_target
+      config = build_config(
+        isolation: :in_process,
+        target_files: [File.join(@tmp, "app", "models", "user.rb")]
+      )
+      runner = described_class.new(config: config)
+      expect(resolved_isolator_class(runner)).to eq(Evilution::Isolation::InProcess)
+    end
+
+    it "suppresses the warning when quiet is set" do
+      write_rails_target
+      config = build_config(
+        isolation: :in_process,
+        target_files: [File.join(@tmp, "app", "models", "user.rb")],
+        quiet: true
+      )
+      runner = described_class.new(config: config)
+      expect { runner.send(:build_isolator) }.not_to output.to_stderr
+    end
+
+    it "does not warn twice for repeated calls in the same run" do
+      write_rails_target
+      config = build_config(
+        isolation: :in_process,
+        target_files: [File.join(@tmp, "app", "models", "user.rb")],
+        quiet: false
+      )
+      captured = StringIO.new
+      orig = $stderr
+      $stderr = captured
+      runner = described_class.new(config: config) # first warn during initialize
+      runner.send(:build_isolator) # should not warn again
+      runner.send(:build_isolator)
+      $stderr = orig
+      expect(captured.string.scan("handle_interrupt").length).to eq(1)
+    end
+  end
+end

--- a/spec/evilution/runner_preload_spec.rb
+++ b/spec/evilution/runner_preload_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "evilution/runner"
+require "evilution/rails_detector"
+require "fileutils"
+require "tmpdir"
+
+RSpec.describe Evilution::Runner, "preload" do
+  around do |example|
+    Dir.mktmpdir("evilution-runner-preload") do |tmp|
+      @tmp = tmp
+      Evilution::RailsDetector.reset_cache!
+      example.run
+    end
+  end
+
+  def write_rails_tree(preload_body: nil)
+    FileUtils.mkdir_p(File.join(@tmp, "config"))
+    FileUtils.mkdir_p(File.join(@tmp, "app", "models"))
+    FileUtils.mkdir_p(File.join(@tmp, "spec"))
+    File.write(File.join(@tmp, "config", "application.rb"), "# Rails\n")
+    File.write(File.join(@tmp, "app", "models", "user.rb"), "class User; end\n")
+    body = preload_body || "module EvilutionPreloadFixture; LOADED = true; end"
+    File.write(File.join(@tmp, "spec", "rails_helper.rb"), "#{body}\n")
+  end
+
+  def build_config(**overrides)
+    Evilution::Config.new(
+      target_files: [File.join(@tmp, "app", "models", "user.rb")],
+      format: :json,
+      timeout: 5,
+      quiet: true,
+      baseline: false,
+      isolation: :auto,
+      skip_config_file: true,
+      **overrides
+    )
+  end
+
+  describe "Config#preload" do
+    it "defaults to nil (auto-detect)" do
+      expect(build_config.preload).to be_nil
+    end
+
+    it "accepts an explicit path as a String" do
+      expect(build_config(preload: "custom/path.rb").preload).to eq("custom/path.rb")
+    end
+
+    it "accepts false to disable preload" do
+      expect(build_config(preload: false).preload).to be(false)
+    end
+
+    it "rejects unsupported types" do
+      expect { build_config(preload: 42) }.to raise_error(Evilution::ConfigError, /preload/)
+    end
+  end
+
+  describe "#perform_preload" do
+    it "requires spec/rails_helper.rb when isolation resolves to fork and Rails is detected" do
+      write_rails_tree
+      runner = described_class.new(config: build_config)
+      runner.send(:perform_preload)
+      expect(defined?(EvilutionPreloadFixture::LOADED)).to eq("constant")
+    ensure
+      Object.send(:remove_const, :EvilutionPreloadFixture) if defined?(EvilutionPreloadFixture)
+    end
+
+    it "is a no-op when preload is false" do
+      write_rails_tree(preload_body: 'raise "should not be loaded"')
+      runner = described_class.new(config: build_config(preload: false))
+      expect { runner.send(:perform_preload) }.not_to raise_error
+    end
+
+    it "is a no-op when isolation resolves to :in_process" do
+      write_rails_tree(preload_body: 'raise "should not be loaded"')
+      # Explicit :in_process on Rails — user accepted the warning, no preload
+      runner = described_class.new(
+        config: build_config(isolation: :in_process, quiet: true)
+      )
+      expect { runner.send(:perform_preload) }.not_to raise_error
+    end
+
+    it "is a no-op on a non-Rails project" do
+      FileUtils.mkdir_p(File.join(@tmp, "lib"))
+      File.write(File.join(@tmp, "lib", "thing.rb"), "class Thing; end\n")
+      runner = described_class.new(
+        config: build_config(target_files: [File.join(@tmp, "lib", "thing.rb")])
+      )
+      expect { runner.send(:perform_preload) }.not_to raise_error
+    end
+
+    it "honors an explicit preload path" do
+      FileUtils.mkdir_p(File.join(@tmp, "custom"))
+      File.write(
+        File.join(@tmp, "custom", "bootstrap.rb"),
+        "module EvilutionPreloadFixtureCustom; LOADED = true; end"
+      )
+      write_rails_tree(preload_body: 'raise "default should not be loaded"')
+      runner = described_class.new(
+        config: build_config(preload: File.join(@tmp, "custom", "bootstrap.rb"))
+      )
+      runner.send(:perform_preload)
+      expect(defined?(EvilutionPreloadFixtureCustom::LOADED)).to eq("constant")
+    ensure
+      Object.send(:remove_const, :EvilutionPreloadFixtureCustom) if defined?(EvilutionPreloadFixtureCustom)
+    end
+
+    it "raises ConfigError when the preload file exists but raises on load" do
+      write_rails_tree(preload_body: 'raise "boom in preload"')
+      runner = described_class.new(config: build_config)
+      expect { runner.send(:perform_preload) }.to raise_error(Evilution::ConfigError, /preload/)
+    end
+
+    it "raises ConfigError when an explicit preload path does not exist" do
+      write_rails_tree
+      runner = described_class.new(
+        config: build_config(preload: File.join(@tmp, "does_not_exist.rb"))
+      )
+      expect { runner.send(:perform_preload) }.to raise_error(Evilution::ConfigError, /preload/)
+    end
+  end
+end

--- a/spec/evilution/runner_preload_spec.rb
+++ b/spec/evilution/runner_preload_spec.rb
@@ -118,5 +118,11 @@ RSpec.describe Evilution::Runner, "preload" do
       )
       expect { runner.send(:perform_preload) }.to raise_error(Evilution::ConfigError, /preload/)
     end
+
+    it "raises ConfigError when the preload file has a SyntaxError" do
+      write_rails_tree(preload_body: "def broken(")
+      runner = described_class.new(config: build_config)
+      expect { runner.send(:perform_preload) }.to raise_error(Evilution::ConfigError, /preload/)
+    end
   end
 end


### PR DESCRIPTION
- Introduced documentation for isolation strategies in `isolation.md`.
- Enhanced CLI options to include `--preload` and `--no-preload`.
- Updated configuration to support preload settings.
- Implemented Rails detection for preload in the runner.
- Added tests for isolation resolution and preload functionality.