### PR TITLE
735: Enhance integration with spec selector for Minitest and RSpec

### DIFF
--- a/lib/evilution/config.rb
+++ b/lib/evilution/config.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "yaml"
+require_relative "spec_resolver"
 require_relative "spec_selector"
 
 class Evilution::Config
@@ -238,8 +239,18 @@ class Evilution::Config
     Evilution::SpecSelector.new(
       spec_files: @spec_files,
       spec_mappings: @spec_mappings,
-      spec_pattern: @spec_pattern
+      spec_pattern: @spec_pattern,
+      spec_resolver: build_spec_resolver
     )
+  end
+
+  def build_spec_resolver
+    case @integration
+    when :minitest
+      Evilution::SpecResolver.new(test_dir: "test", test_suffix: "_test.rb", request_dir: "integration")
+    else
+      Evilution::SpecResolver.new
+    end
   end
 
   def validate_spec_mappings(value)

--- a/lib/evilution/integration/minitest.rb
+++ b/lib/evilution/integration/minitest.rb
@@ -141,8 +141,8 @@ class Evilution::Integration::Minitest < Evilution::Integration::Base
   def resolve_test_files(mutation)
     return test_files if test_files
 
-    resolved = @spec_selector.call(mutation.file_path)
-    if resolved.nil? || resolved.empty?
+    resolved = Array(@spec_selector.call(mutation.file_path))
+    if resolved.empty?
       warn_unresolved_test(mutation.file_path)
       return @fallback_to_full_suite ? glob_test_files : nil
     end

--- a/lib/evilution/integration/minitest.rb
+++ b/lib/evilution/integration/minitest.rb
@@ -4,6 +4,7 @@ require "stringio"
 require_relative "base"
 require_relative "minitest_crash_detector"
 require_relative "../spec_resolver"
+require_relative "../spec_selector"
 
 require_relative "../integration"
 
@@ -35,10 +36,12 @@ class Evilution::Integration::Minitest < Evilution::Integration::Base
     }
   end
 
-  def initialize(test_files: nil, hooks: nil, fallback_to_full_suite: false)
+  def initialize(test_files: nil, hooks: nil, fallback_to_full_suite: false, spec_selector: nil)
     @test_files = test_files
     @minitest_loaded = false
-    @spec_resolver = Evilution::SpecResolver.new(test_dir: "test", test_suffix: "_test.rb", request_dir: "integration")
+    @spec_selector = spec_selector || Evilution::SpecSelector.new(
+      spec_resolver: Evilution::SpecResolver.new(test_dir: "test", test_suffix: "_test.rb", request_dir: "integration")
+    )
     @fallback_to_full_suite = fallback_to_full_suite
     @crash_detector = nil
     @warned_files = Set.new
@@ -138,13 +141,13 @@ class Evilution::Integration::Minitest < Evilution::Integration::Base
   def resolve_test_files(mutation)
     return test_files if test_files
 
-    resolved = @spec_resolver.call(mutation.file_path)
-    unless resolved
+    resolved = @spec_selector.call(mutation.file_path)
+    if resolved.nil? || resolved.empty?
       warn_unresolved_test(mutation.file_path)
       return @fallback_to_full_suite ? glob_test_files : nil
     end
 
-    [resolved]
+    resolved
   end
 
   def glob_test_files

--- a/lib/evilution/integration/rspec.rb
+++ b/lib/evilution/integration/rspec.rb
@@ -168,8 +168,8 @@ class Evilution::Integration::RSpec < Evilution::Integration::Base
   def resolve_test_files(mutation)
     return test_files if test_files
 
-    resolved = @spec_selector.call(mutation.file_path)
-    if resolved.nil? || resolved.empty?
+    resolved = Array(@spec_selector.call(mutation.file_path))
+    if resolved.empty?
       warn_unresolved_spec(mutation.file_path)
       return @fallback_to_full_suite ? ["spec"] : nil
     end

--- a/lib/evilution/integration/rspec.rb
+++ b/lib/evilution/integration/rspec.rb
@@ -70,6 +70,8 @@ class Evilution::Integration::RSpec < Evilution::Integration::Base
 
     detector = reset_crash_detector
     eg_before = snapshot_example_groups
+    fe_before = snapshot_filtered_examples_keys
+    rep_before = snapshot_reporter_lengths
     status = ::RSpec::Core::Runner.run(args, out, err)
 
     build_rspec_result(status, command, detector)
@@ -77,6 +79,8 @@ class Evilution::Integration::RSpec < Evilution::Integration::Base
     { passed: false, error: e.message, test_command: command }
   ensure
     release_rspec_state(eg_before)
+    release_filtered_examples(fe_before)
+    release_reporter_state(rep_before)
   end
 
   def build_args(files)
@@ -138,6 +142,54 @@ class Evilution::Integration::RSpec < Evilution::Integration::Base
     world = ::RSpec.world
     world.instance_variable_get(:@example_groups).clear if world.instance_variable_defined?(:@example_groups)
     world.instance_variable_set(:@sources_by_path, {}) if world.instance_variable_defined?(:@sources_by_path)
+  end
+
+  def snapshot_filtered_examples_keys
+    fe = rspec_world_ivar(:@filtered_examples)
+    fe ? Set.new(fe.keys.map(&:object_id)) : nil
+  end
+
+  def snapshot_reporter_lengths
+    reporter = rspec_config_ivar(:@reporter)
+    return nil unless reporter
+
+    %i[@examples @failed_examples @pending_examples].each_with_object({}) do |ivar, acc|
+      next unless reporter.instance_variable_defined?(ivar)
+
+      arr = reporter.instance_variable_get(ivar)
+      acc[ivar] = arr.length if arr.is_a?(Array)
+    end
+  end
+
+  def release_filtered_examples(snapshot_keys)
+    fe = rspec_world_ivar(:@filtered_examples)
+    return unless fe && snapshot_keys
+
+    fe.each_key.to_a.each do |k|
+      fe.delete(k) unless snapshot_keys.include?(k.object_id)
+    end
+  end
+
+  def release_reporter_state(lengths)
+    return unless lengths
+
+    reporter = rspec_config_ivar(:@reporter)
+    return unless reporter
+
+    lengths.each do |ivar, length|
+      arr = reporter.instance_variable_get(ivar)
+      arr.slice!(length..) if arr.is_a?(Array) && arr.length > length
+    end
+  end
+
+  def rspec_world_ivar(ivar)
+    world = ::RSpec.world
+    world.instance_variable_defined?(ivar) ? world.instance_variable_get(ivar) : nil
+  end
+
+  def rspec_config_ivar(ivar)
+    config = ::RSpec.configuration
+    config.instance_variable_defined?(ivar) ? config.instance_variable_get(ivar) : nil
   end
 
   def reset_crash_detector

--- a/lib/evilution/runner/baseline_runner.rb
+++ b/lib/evilution/runner/baseline_runner.rb
@@ -29,11 +29,13 @@ class Evilution::Runner::BaselineRunner
   def build_integration
     klass = integration_class
     test_files = config.spec_files.empty? ? nil : config.spec_files
-    kwargs = { test_files: test_files, hooks: hooks, fallback_to_full_suite: config.fallback_to_full_suite? }
-    if klass == Evilution::Integration::RSpec
-      kwargs[:related_specs_heuristic] = config.related_specs_heuristic?
-      kwargs[:spec_selector] = config.spec_selector
-    end
+    kwargs = {
+      test_files: test_files,
+      hooks: hooks,
+      fallback_to_full_suite: config.fallback_to_full_suite?,
+      spec_selector: config.spec_selector
+    }
+    kwargs[:related_specs_heuristic] = config.related_specs_heuristic? if klass == Evilution::Integration::RSpec
     klass.new(**kwargs)
   end
 

--- a/script/memory_check
+++ b/script/memory_check
@@ -7,8 +7,8 @@ require_relative "../lib/evilution/integration/rspec"
 
 FIXTURE = File.expand_path("../spec/support/fixtures/simple_class.rb", __dir__)
 FIXTURE_SPEC = File.expand_path("../spec/support/fixtures/simple_class_spec.rb", __dir__)
-COMPLEX_FIXTURE = File.expand_path("../lib/evilution/config.rb", __dir__)
-COMPLEX_FIXTURE_SPEC = File.expand_path("../spec/evilution/config_spec.rb", __dir__)
+COMPLEX_FIXTURE = File.expand_path("../spec/support/fixtures/memory_check/target.rb", __dir__)
+COMPLEX_FIXTURE_SPEC = File.expand_path("../spec/support/fixtures/memory_check/target_examples.rb", __dir__)
 ITERATIONS = Integer(ENV.fetch("MEMORY_CHECK_ITERATIONS", 50))
 MAX_GROWTH_KB = Integer(ENV.fetch("MEMORY_CHECK_MAX_GROWTH_KB", 10_240))
 
@@ -95,8 +95,10 @@ if mutations.size >= 2
 end
 
 # 5. RSpec integration per-mutation with complex fixture
-#    Uses Config (227 LOC, 73 specs, 564 mutations) for realistic per-mutation load:
-#    more ExampleGroup subclasses, deeper spec nesting, heavier metadata.
+#    Uses a frozen snapshot under spec/support/fixtures/memory_check/ for
+#    realistic per-mutation load: deep spec nesting, heavy metadata. Snapshot
+#    is intentional - decoupling the budget from project file growth so this
+#    check measures integration plumbing memory, not project size.
 complex_parser = Evilution::AST::Parser.new
 complex_registry = Evilution::Mutator::Registry.default
 complex_subjects = complex_parser.call(COMPLEX_FIXTURE)
@@ -105,7 +107,7 @@ complex_mutations = complex_subjects.flat_map { |s| complex_registry.mutations_f
 integration = Evilution::Integration::RSpec.new(test_files: [COMPLEX_FIXTURE_SPEC])
 
 # Budget is generous: per-mutation require() adds the file to $LOADED_FEATURES and
-# accumulates constant-redefinition warnings. Local runs land around 20-25 MB; CI
+# accumulates constant-redefinition warnings. Local runs land around 20 MB; CI
 # varies up to ~30 MB depending on Ruby build and GC pressure, so we leave headroom.
 all_passed &= run_check("RSpec integration per-mutation (Config)", iterations: 20, max_growth_kb: 40_960) do
   mutation = complex_mutations.sample

--- a/spec/evilution/config_spec.rb
+++ b/spec/evilution/config_spec.rb
@@ -457,6 +457,30 @@ RSpec.describe Evilution::Config do
         end
       end
     end
+
+    it "resolves test/ paths when integration is :minitest" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          FileUtils.mkdir_p("test/foo")
+          File.write("test/foo/bar_test.rb", "")
+          config = described_class.new(skip_config_file: true, integration: :minitest)
+
+          expect(config.spec_selector.call("lib/foo/bar.rb")).to eq(["test/foo/bar_test.rb"])
+        end
+      end
+    end
+
+    it "resolves spec/ paths when integration is :rspec" do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          FileUtils.mkdir_p("spec/foo")
+          File.write("spec/foo/bar_spec.rb", "")
+          config = described_class.new(skip_config_file: true, integration: :rspec)
+
+          expect(config.spec_selector.call("lib/foo/bar.rb")).to eq(["spec/foo/bar_spec.rb"])
+        end
+      end
+    end
   end
 
   describe ".default_template" do

--- a/spec/evilution/integration/minitest_spec.rb
+++ b/spec/evilution/integration/minitest_spec.rb
@@ -191,6 +191,27 @@ RSpec.describe Evilution::Integration::Minitest do
       expect(result[:unresolved]).to be_falsey
       expect(result[:test_command]).to include("test")
     end
+
+    it "uses injected spec_selector when provided" do
+      injected = instance_double(Evilution::SpecSelector)
+      allow(injected).to receive(:call).with(mutation.file_path).and_return(["test/injected_test.rb"])
+      custom = described_class.new(spec_selector: injected)
+      allow(custom).to receive(:load)
+
+      expect(custom).to receive(:load).with(File.expand_path("test/injected_test.rb"))
+
+      custom.call(mutation)
+    end
+
+    it "returns unresolved when injected spec_selector returns nil" do
+      injected = instance_double(Evilution::SpecSelector)
+      allow(injected).to receive(:call).with(mutation.file_path).and_return(nil)
+      custom = described_class.new(spec_selector: injected)
+
+      result = custom.call(mutation)
+
+      expect(result[:unresolved]).to be true
+    end
   end
 
   describe "crash detection" do

--- a/spec/evilution/runner/baseline_runner_spec.rb
+++ b/spec/evilution/runner/baseline_runner_spec.rb
@@ -62,6 +62,26 @@ RSpec.describe Evilution::Runner::BaselineRunner do
       end
       runner.build_integration
     end
+
+    it "passes spec_selector for RSpec integration" do
+      cfg = config(integration: :rspec)
+      runner = described_class.new(cfg)
+      expect(Evilution::Integration::RSpec).to receive(:new) do |**kwargs|
+        expect(kwargs[:spec_selector]).to be(cfg.spec_selector)
+        Evilution::Integration::RSpec.allocate
+      end
+      runner.build_integration
+    end
+
+    it "passes spec_selector for Minitest integration" do
+      cfg = config(integration: :minitest)
+      runner = described_class.new(cfg)
+      expect(Evilution::Integration::Minitest).to receive(:new) do |**kwargs|
+        expect(kwargs[:spec_selector]).to be(cfg.spec_selector)
+        Evilution::Integration::Minitest.allocate
+      end
+      runner.build_integration
+    end
   end
 
   describe "#call" do

--- a/spec/support/fixtures/memory_check/target.rb
+++ b/spec/support/fixtures/memory_check/target.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+class Evilution::Config
+  CONFIG_FILES = %w[.evilution.yml config/evilution.yml].freeze
+
+  DEFAULTS = {
+    timeout: 30,
+    format: :text,
+    target: nil,
+    min_score: 0.0,
+    integration: :rspec,
+    verbose: false,
+    quiet: false,
+    jobs: 1,
+    fail_fast: nil,
+    baseline: true,
+    isolation: :auto,
+    incremental: false,
+    suggest_tests: false,
+    progress: true,
+    save_session: false,
+    line_ranges: {},
+    spec_files: [],
+    ignore_patterns: [],
+    show_disabled: false,
+    baseline_session: nil,
+    skip_heredoc_literals: false,
+    related_specs_heuristic: false,
+    fallback_to_full_suite: false,
+    preload: nil
+  }.freeze
+
+  attr_reader :target_files, :timeout, :format,
+              :target, :min_score, :integration, :verbose, :quiet,
+              :jobs, :fail_fast, :baseline, :isolation, :incremental, :suggest_tests,
+              :progress, :save_session, :line_ranges, :spec_files, :hooks,
+              :ignore_patterns, :show_disabled, :baseline_session,
+              :skip_heredoc_literals, :related_specs_heuristic,
+              :fallback_to_full_suite, :preload
+
+  def initialize(**options)
+    file_options = options.delete(:skip_config_file) ? {} : load_config_file
+    merged = DEFAULTS.merge(file_options).merge(options)
+    assign_attributes(merged)
+    freeze
+  end
+
+  def json?
+    format == :json
+  end
+
+  def text?
+    format == :text
+  end
+
+  def html?
+    format == :html
+  end
+
+  def line_ranges?
+    !line_ranges.empty?
+  end
+
+  def target?
+    !target.nil?
+  end
+
+  def fail_fast?
+    !fail_fast.nil?
+  end
+
+  def baseline?
+    baseline
+  end
+
+  def incremental?
+    incremental
+  end
+
+  def suggest_tests?
+    suggest_tests
+  end
+
+  def progress?
+    progress
+  end
+
+  def save_session?
+    save_session
+  end
+
+  def show_disabled?
+    show_disabled
+  end
+
+  def skip_heredoc_literals?
+    skip_heredoc_literals
+  end
+
+  def related_specs_heuristic?
+    related_specs_heuristic
+  end
+
+  def fallback_to_full_suite?
+    fallback_to_full_suite
+  end
+
+  def self.file_options
+    CONFIG_FILES.each do |path|
+      next unless File.exist?(path)
+
+      data = YAML.safe_load_file(path, symbolize_names: true)
+      return data.is_a?(Hash) ? data : {}
+    rescue Psych::SyntaxError, Psych::DisallowedClass => e
+      raise Evilution::ConfigError.new("failed to parse config file #{path}: #{e.message}", file: path)
+    rescue SystemCallError => e
+      raise Evilution::ConfigError.new("cannot read config file #{path}: #{e.message}", file: path)
+    end
+
+    {}
+  end
+
+  # Generates a default config file template.
+  def self.default_template
+    <<~YAML
+      # Evilution configuration
+      # See: https://github.com/marinazzio/evilution
+
+      # Per-mutation timeout in seconds (default: 30)
+      # timeout: 30
+
+      # Output format: text or json (default: text)
+      # format: text
+
+      # Minimum mutation score to pass (0.0 to 1.0, default: 0.0)
+      # min_score: 0.0
+
+      # Test integration: rspec, minitest (default: rspec)
+      # integration: rspec
+
+      # Number of parallel workers (default: 1)
+      # jobs: 1
+
+      # Stop after N surviving mutants (default: disabled)
+      # fail_fast: 1
+
+      # Generate concrete test code in suggestions, matching integration (default: false)
+      # suggest_tests: false
+
+      # Skip all string literal mutations inside heredocs (default: false).
+      # Useful for Rails apps where heredoc content (SQL, templates, fixtures)
+      # rarely has meaningful test coverage and produces noisy survivors.
+      # skip_heredoc_literals: true
+
+      # Opt into the RelatedSpecHeuristic, which appends request/integration/
+      # feature/system specs for mutations that touch `.includes(...)` calls
+      # (default: false). Off by default because the fan-out can be heavy and
+      # push runs over the per-mutation timeout. Enable if you need coverage
+      # of N+1 regressions that only surface in higher-level specs.
+      # related_specs_heuristic: true
+
+      # When no matching spec resolves for a mutation's source file, the
+      # default is to skip that mutation and mark it :unresolved in the
+      # report (a coverage gap signal). Set to true to fall back to running
+      # the entire test suite for such mutations instead (slow, high memory).
+      # fallback_to_full_suite: false
+
+      # Preload file required in the parent process before forking workers.
+      # For Rails projects, spec/rails_helper.rb or test/test_helper.rb is
+      # auto-detected when isolation resolves to :fork. Set to false to disable.
+      # preload: spec/rails_helper.rb # or test/test_helper.rb
+
+      # Hooks: Ruby files returning a Proc, keyed by lifecycle event
+      # hooks:
+      #   worker_process_start: config/evilution_hooks/worker_start.rb
+      #   mutation_insert_pre: config/evilution_hooks/mutation_pre.rb
+
+      # AST patterns to skip during mutation generation (default: [])
+      # See docs/ast_pattern_syntax.md for pattern syntax
+      # ignore_patterns:
+      #   - "call{name=info, receiver=call{name=logger}}"
+      #   - "call{name=debug|warn}"
+    YAML
+  end
+
+  private
+
+  def validate_fail_fast(value)
+    return nil if value.nil?
+
+    value = Integer(value)
+    raise Evilution::ConfigError, "fail_fast must be a positive integer, got #{value}" unless value >= 1
+
+    value
+  rescue ::ArgumentError, ::TypeError
+    raise Evilution::ConfigError, "fail_fast must be a positive integer, got #{value.inspect}"
+  end
+
+  def assign_attributes(merged) # rubocop:disable Metrics/AbcSize
+    @target_files = Array(merged[:target_files])
+    @timeout = merged[:timeout]
+    @format = merged[:format].to_sym
+    @target = merged[:target]
+    @min_score = merged[:min_score].to_f
+    @integration = validate_integration(merged[:integration])
+    @verbose = merged[:verbose]
+    @quiet = merged[:quiet]
+    @jobs = validate_jobs(merged[:jobs])
+    @fail_fast = validate_fail_fast(merged[:fail_fast])
+    @baseline = merged[:baseline]
+    @isolation = validate_isolation(merged[:isolation])
+    @incremental = merged[:incremental]
+    @suggest_tests = merged[:suggest_tests]
+    @progress = merged[:progress]
+    @save_session = merged[:save_session]
+    @line_ranges = merged[:line_ranges] || {}
+    @spec_files = Array(merged[:spec_files])
+    @ignore_patterns = validate_ignore_patterns(merged[:ignore_patterns])
+    @show_disabled = merged[:show_disabled]
+    @baseline_session = merged[:baseline_session]
+    @skip_heredoc_literals = merged[:skip_heredoc_literals]
+    @related_specs_heuristic = merged[:related_specs_heuristic]
+    @fallback_to_full_suite = merged[:fallback_to_full_suite]
+    @hooks = validate_hooks(merged[:hooks])
+    @preload = validate_preload(merged[:preload])
+  end
+
+  def validate_preload(value)
+    return nil if value.nil?
+    return false if value == false
+    return value if value.is_a?(String)
+
+    raise Evilution::ConfigError, "preload must be nil, false, or a String path, got #{value.inspect}"
+  end
+
+  def validate_integration(value)
+    raise Evilution::ConfigError, "integration must be rspec or minitest, got nil" if value.nil?
+
+    value = value.to_sym
+    unless %i[rspec minitest].include?(value)
+      raise Evilution::ConfigError,
+            "integration must be rspec or minitest, got #{value.inspect}"
+    end
+
+    value
+  end
+
+  def validate_isolation(value)
+    raise Evilution::ConfigError, "isolation must be auto, fork, or in_process, got nil" if value.nil?
+
+    value = value.to_sym
+    raise Evilution::ConfigError, "isolation must be auto, fork, or in_process, got #{value.inspect}" unless %i[auto fork
+                                                                                                                in_process].include?(value)
+
+    value
+  end
+
+  def validate_jobs(value)
+    raise Evilution::ConfigError, "jobs must be a positive integer, got #{value.inspect}" if value.is_a?(Float)
+
+    value = Integer(value)
+    raise Evilution::ConfigError, "jobs must be a positive integer, got #{value}" unless value >= 1
+
+    value
+  rescue ::ArgumentError, ::TypeError
+    raise Evilution::ConfigError, "jobs must be a positive integer, got #{value.inspect}"
+  end
+
+  def validate_ignore_patterns(value)
+    patterns = Array(value)
+    patterns.each do |pattern|
+      unless pattern.is_a?(String)
+        raise Evilution::ConfigError,
+              "ignore_patterns must be an array of strings, got #{pattern.class} (#{pattern.inspect})"
+      end
+    end
+    patterns
+  end
+
+  def validate_hooks(value)
+    return {} if value.nil?
+    raise Evilution::ConfigError, "hooks must be a mapping of event names to file paths, got #{value.class}" unless value.is_a?(Hash)
+
+    value
+  end
+
+  def load_config_file
+    self.class.file_options
+  end
+end

--- a/spec/support/fixtures/memory_check/target_examples.rb
+++ b/spec/support/fixtures/memory_check/target_examples.rb
@@ -1,0 +1,600 @@
+# frozen_string_literal: true
+
+require "tempfile"
+
+RSpec.describe Evilution::Config do
+  describe "defaults" do
+    subject(:config) { described_class.new(skip_config_file: true) }
+
+    it "sets target_files to empty array" do
+      expect(config.target_files).to eq([])
+    end
+
+    it "sets timeout to 30 seconds" do
+      expect(config.timeout).to eq(30)
+    end
+
+    it "sets format to :text" do
+      expect(config.format).to eq(:text)
+    end
+
+    it "sets min_score to 0.0" do
+      expect(config.min_score).to eq(0.0)
+    end
+
+    it "sets integration to :rspec" do
+      expect(config.integration).to eq(:rspec)
+    end
+
+    it "disables verbose by default" do
+      expect(config.verbose).to be false
+    end
+
+    it "disables quiet by default" do
+      expect(config.quiet).to be false
+    end
+
+    it "sets fail_fast to nil" do
+      expect(config.fail_fast).to be_nil
+    end
+
+    it "sets line_ranges to empty hash" do
+      expect(config.line_ranges).to eq({})
+    end
+
+    it "sets spec_files to empty array" do
+      expect(config.spec_files).to eq([])
+    end
+
+    it "disables suggest_tests by default" do
+      expect(config.suggest_tests).to be false
+    end
+  end
+
+  describe "custom options" do
+    it "accepts target_files as array" do
+      config = described_class.new(target_files: ["lib/foo.rb", "lib/bar.rb"], skip_config_file: true)
+
+      expect(config.target_files).to eq(["lib/foo.rb", "lib/bar.rb"])
+    end
+
+    it "wraps single target_file in array" do
+      config = described_class.new(target_files: "lib/foo.rb", skip_config_file: true)
+
+      expect(config.target_files).to eq(["lib/foo.rb"])
+    end
+
+    it "accepts custom jobs" do
+      config = described_class.new(jobs: 4, skip_config_file: true)
+
+      expect(config.jobs).to eq(4)
+    end
+
+    it "accepts custom timeout" do
+      config = described_class.new(timeout: 30, skip_config_file: true)
+
+      expect(config.timeout).to eq(30)
+    end
+
+    it "accepts format as string" do
+      config = described_class.new(format: "json", skip_config_file: true)
+
+      expect(config.format).to eq(:json)
+    end
+
+    it "accepts min_score" do
+      config = described_class.new(min_score: 0.9, skip_config_file: true)
+
+      expect(config.min_score).to eq(0.9)
+    end
+
+    it "accepts spec_files" do
+      config = described_class.new(spec_files: ["spec/foo_spec.rb"], skip_config_file: true)
+
+      expect(config.spec_files).to eq(["spec/foo_spec.rb"])
+    end
+
+    it "wraps single spec_file in array" do
+      config = described_class.new(spec_files: "spec/foo_spec.rb", skip_config_file: true)
+
+      expect(config.spec_files).to eq(["spec/foo_spec.rb"])
+    end
+
+    it "defaults hooks to empty hash" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.hooks).to eq({})
+    end
+
+    it "accepts hooks configuration" do
+      hooks_config = { worker_process_start: "config/hooks/worker.rb" }
+      config = described_class.new(hooks: hooks_config, skip_config_file: true)
+
+      expect(config.hooks).to eq(hooks_config)
+    end
+
+    it "rejects non-hash hooks value" do
+      expect { described_class.new(hooks: "not_a_hash", skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /hooks must be a mapping/)
+    end
+
+    it "rejects array hooks value" do
+      expect { described_class.new(hooks: ["file.rb"], skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /hooks must be a mapping/)
+    end
+
+    it "accepts fail_fast" do
+      config = described_class.new(fail_fast: 3, skip_config_file: true)
+
+      expect(config.fail_fast).to eq(3)
+    end
+
+    it "accepts suggest_tests" do
+      config = described_class.new(suggest_tests: true, skip_config_file: true)
+
+      expect(config.suggest_tests).to be true
+    end
+  end
+
+  describe "config file loading" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) { example.run }
+      end
+    end
+
+    it "loads settings from .evilution.yml" do
+      File.write(".evilution.yml", "timeout: 30\nformat: json\n")
+
+      config = described_class.new
+
+      expect(config.timeout).to eq(30)
+      expect(config.format).to eq(:json)
+    end
+
+    it "loads settings from config/evilution.yml" do
+      Dir.mkdir("config")
+      File.write("config/evilution.yml", "timeout: 20\n")
+
+      config = described_class.new
+
+      expect(config.timeout).to eq(20)
+    end
+
+    it "prefers .evilution.yml over config/evilution.yml" do
+      File.write(".evilution.yml", "timeout: 30\n")
+      Dir.mkdir("config")
+      File.write("config/evilution.yml", "timeout: 20\n")
+
+      config = described_class.new
+
+      expect(config.timeout).to eq(30)
+    end
+
+    it "CLI options override file settings" do
+      File.write(".evilution.yml", "timeout: 30\n")
+
+      config = described_class.new(timeout: 5)
+
+      expect(config.timeout).to eq(5)
+    end
+
+    it "handles empty config file gracefully" do
+      File.write(".evilution.yml", "")
+
+      config = described_class.new
+
+      expect(config.timeout).to eq(30) # default
+    end
+
+    it "loads ignore_patterns from YAML" do
+      yaml = <<~YAML
+        ignore_patterns:
+          - "call{name=info, receiver=call{name=logger}}"
+          - "call{name=debug|warn}"
+      YAML
+      File.write(".evilution.yml", yaml)
+
+      config = described_class.new
+
+      expect(config.ignore_patterns).to eq([
+                                             "call{name=info, receiver=call{name=logger}}",
+                                             "call{name=debug|warn}"
+                                           ])
+    end
+
+    it "defaults ignore_patterns to empty when not in YAML" do
+      File.write(".evilution.yml", "timeout: 10\n")
+
+      config = described_class.new
+
+      expect(config.ignore_patterns).to eq([])
+    end
+
+    it "CLI options override ignore_patterns from file" do
+      File.write(".evilution.yml", "ignore_patterns:\n  - \"call{name=log}\"\n")
+
+      config = described_class.new(ignore_patterns: ["call{name=debug}"])
+
+      expect(config.ignore_patterns).to eq(["call{name=debug}"])
+    end
+
+    it "loads skip_heredoc_literals from YAML" do
+      File.write(".evilution.yml", "skip_heredoc_literals: true\n")
+
+      config = described_class.new
+
+      expect(config.skip_heredoc_literals?).to be true
+    end
+
+    it "defaults skip_heredoc_literals to false when not in YAML" do
+      File.write(".evilution.yml", "timeout: 10\n")
+
+      config = described_class.new
+
+      expect(config.skip_heredoc_literals?).to be false
+    end
+
+    it "CLI options override skip_heredoc_literals from file" do
+      File.write(".evilution.yml", "skip_heredoc_literals: true\n")
+
+      config = described_class.new(skip_heredoc_literals: false)
+
+      expect(config.skip_heredoc_literals?).to be false
+    end
+
+    it "loads related_specs_heuristic from YAML" do
+      File.write(".evilution.yml", "related_specs_heuristic: true\n")
+
+      config = described_class.new
+
+      expect(config.related_specs_heuristic?).to be true
+    end
+
+    it "defaults related_specs_heuristic to false when not in YAML" do
+      File.write(".evilution.yml", "timeout: 10\n")
+
+      config = described_class.new
+
+      expect(config.related_specs_heuristic?).to be false
+    end
+
+    it "CLI options override related_specs_heuristic from file" do
+      File.write(".evilution.yml", "related_specs_heuristic: true\n")
+
+      config = described_class.new(related_specs_heuristic: false)
+
+      expect(config.related_specs_heuristic?).to be false
+    end
+
+    it "defaults fallback_to_full_suite to false" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.fallback_to_full_suite?).to be false
+    end
+
+    it "loads fallback_to_full_suite from YAML" do
+      File.write(".evilution.yml", "fallback_to_full_suite: true\n")
+
+      config = described_class.new
+
+      expect(config.fallback_to_full_suite?).to be true
+    end
+
+    it "CLI options override fallback_to_full_suite from file" do
+      File.write(".evilution.yml", "fallback_to_full_suite: true\n")
+
+      config = described_class.new(fallback_to_full_suite: false)
+
+      expect(config.fallback_to_full_suite?).to be false
+    end
+  end
+
+  describe ".default_template" do
+    it "returns a YAML string with commented-out options" do
+      template = described_class.default_template
+
+      expect(template).to include("# timeout:")
+      expect(template).to include("# format:")
+    end
+  end
+
+  describe "#json?" do
+    it "returns true when format is json" do
+      config = described_class.new(format: :json, skip_config_file: true)
+
+      expect(config.json?).to be true
+    end
+
+    it "returns false when format is text" do
+      config = described_class.new(format: :text, skip_config_file: true)
+
+      expect(config.json?).to be false
+    end
+  end
+
+  describe "#text?" do
+    it "returns true when format is text" do
+      config = described_class.new(format: :text, skip_config_file: true)
+
+      expect(config.text?).to be true
+    end
+
+    it "returns false when format is json" do
+      config = described_class.new(format: :json, skip_config_file: true)
+
+      expect(config.text?).to be false
+    end
+  end
+
+  describe "#html?" do
+    it "returns true when format is html" do
+      config = described_class.new(format: :html, skip_config_file: true)
+
+      expect(config.html?).to be true
+    end
+
+    it "returns false when format is text" do
+      config = described_class.new(format: :text, skip_config_file: true)
+
+      expect(config.html?).to be false
+    end
+  end
+
+  describe "#line_ranges?" do
+    it "returns true when line_ranges is non-empty" do
+      config = described_class.new(line_ranges: { "lib/foo.rb" => 10..20 }, skip_config_file: true)
+
+      expect(config.line_ranges?).to be true
+    end
+
+    it "returns false when line_ranges is empty" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.line_ranges?).to be false
+    end
+  end
+
+  describe "#target?" do
+    it "returns true when target is set" do
+      config = described_class.new(target: "Foo#bar", skip_config_file: true)
+
+      expect(config.target?).to be true
+    end
+
+    it "returns false when target is nil" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.target?).to be false
+    end
+  end
+
+  describe "#fail_fast?" do
+    it "returns true when fail_fast is set" do
+      config = described_class.new(fail_fast: 1, skip_config_file: true)
+
+      expect(config.fail_fast?).to be true
+    end
+
+    it "returns false when fail_fast is nil" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.fail_fast?).to be false
+    end
+  end
+
+  describe "#suggest_tests?" do
+    it "returns true when suggest_tests is enabled" do
+      config = described_class.new(suggest_tests: true, skip_config_file: true)
+
+      expect(config.suggest_tests?).to be true
+    end
+
+    it "returns false when suggest_tests is disabled" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.suggest_tests?).to be false
+    end
+  end
+
+  describe "#progress?" do
+    it "returns true by default" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.progress?).to be true
+    end
+
+    it "returns false when progress is disabled" do
+      config = described_class.new(progress: false, skip_config_file: true)
+
+      expect(config.progress?).to be false
+    end
+  end
+
+  describe "#show_disabled?" do
+    it "returns false by default" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.show_disabled?).to be false
+    end
+
+    it "returns true when show_disabled is enabled" do
+      config = described_class.new(show_disabled: true, skip_config_file: true)
+
+      expect(config.show_disabled?).to be true
+    end
+  end
+
+  describe "#skip_heredoc_literals?" do
+    it "returns false by default" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.skip_heredoc_literals?).to be false
+    end
+
+    it "returns true when skip_heredoc_literals is enabled" do
+      config = described_class.new(skip_heredoc_literals: true, skip_config_file: true)
+
+      expect(config.skip_heredoc_literals?).to be true
+    end
+  end
+
+  describe "#related_specs_heuristic?" do
+    it "returns false by default" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.related_specs_heuristic?).to be false
+    end
+
+    it "returns true when related_specs_heuristic is enabled" do
+      config = described_class.new(related_specs_heuristic: true, skip_config_file: true)
+
+      expect(config.related_specs_heuristic?).to be true
+    end
+  end
+
+  describe "fail_fast validation" do
+    it "rejects zero" do
+      expect { described_class.new(fail_fast: 0, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /positive integer/)
+    end
+
+    it "rejects negative values" do
+      expect { described_class.new(fail_fast: -1, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /positive integer/)
+    end
+
+    it "rejects non-integer string values" do
+      expect { described_class.new(fail_fast: "abc", skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /positive integer/)
+    end
+
+    it "rejects boolean values" do
+      expect { described_class.new(fail_fast: true, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /positive integer/)
+    end
+  end
+
+  describe "jobs validation" do
+    it "defaults to 1" do
+      config = described_class.new(skip_config_file: true)
+      expect(config.jobs).to eq(1)
+    end
+
+    it "accepts positive integers" do
+      config = described_class.new(jobs: 4, skip_config_file: true)
+      expect(config.jobs).to eq(4)
+    end
+
+    it "rejects zero" do
+      expect { described_class.new(jobs: 0, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /positive integer/)
+    end
+
+    it "rejects negative values" do
+      expect { described_class.new(jobs: -1, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /positive integer/)
+    end
+
+    it "rejects non-integer string values" do
+      expect { described_class.new(jobs: "abc", skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /positive integer/)
+    end
+
+    it "rejects float values" do
+      expect { described_class.new(jobs: 2.5, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /positive integer/)
+    end
+  end
+
+  describe "isolation validation" do
+    it "defaults to :auto" do
+      config = described_class.new(skip_config_file: true)
+      expect(config.isolation).to eq(:auto)
+    end
+
+    it "accepts :fork" do
+      config = described_class.new(isolation: :fork, skip_config_file: true)
+      expect(config.isolation).to eq(:fork)
+    end
+
+    it "accepts :in_process" do
+      config = described_class.new(isolation: :in_process, skip_config_file: true)
+      expect(config.isolation).to eq(:in_process)
+    end
+
+    it "accepts string values and converts to symbol" do
+      config = described_class.new(isolation: "fork", skip_config_file: true)
+      expect(config.isolation).to eq(:fork)
+    end
+
+    it "rejects invalid values" do
+      expect { described_class.new(isolation: :invalid, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /isolation must be/)
+    end
+
+    it "rejects nil values" do
+      expect { described_class.new(isolation: nil, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /isolation must be/)
+    end
+  end
+
+  describe "integration validation" do
+    it "defaults to :rspec" do
+      config = described_class.new(skip_config_file: true)
+      expect(config.integration).to eq(:rspec)
+    end
+
+    it "accepts :minitest" do
+      config = described_class.new(integration: :minitest, skip_config_file: true)
+      expect(config.integration).to eq(:minitest)
+    end
+
+    it "accepts string values and converts to symbol" do
+      config = described_class.new(integration: "minitest", skip_config_file: true)
+      expect(config.integration).to eq(:minitest)
+    end
+
+    it "rejects invalid values" do
+      expect { described_class.new(integration: :cucumber, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /integration must be/)
+    end
+
+    it "rejects nil values" do
+      expect { described_class.new(integration: nil, skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /integration must be/)
+    end
+  end
+
+  describe "ignore_patterns" do
+    it "defaults to empty array" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config.ignore_patterns).to eq([])
+    end
+
+    it "accepts an array of strings" do
+      config = described_class.new(ignore_patterns: ["call{name=log}"], skip_config_file: true)
+
+      expect(config.ignore_patterns).to eq(["call{name=log}"])
+    end
+
+    it "rejects non-string elements" do
+      expect { described_class.new(ignore_patterns: [123], skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /ignore_patterns must be an array of strings/)
+    end
+
+    it "rejects hash elements" do
+      expect { described_class.new(ignore_patterns: [{ name: "log" }], skip_config_file: true) }
+        .to raise_error(Evilution::ConfigError, /ignore_patterns must be an array of strings/)
+    end
+  end
+
+  describe "immutability" do
+    it "is frozen after initialization" do
+      config = described_class.new(skip_config_file: true)
+
+      expect(config).to be_frozen
+    end
+  end
+end


### PR DESCRIPTION
- Introduced a `spec_selector` parameter in the Minitest and RSpec integration classes.
- Updated the `Config` class to build a `SpecResolver` based on the integration type.
- Added tests to verify the correct resolution of test paths and the behavior of injected spec selectors.