### PR TITLE
749: Add compare command and related functionality to CLI

### DIFF
--- a/lib/evilution/cli.rb
+++ b/lib/evilution/cli.rb
@@ -16,6 +16,7 @@ require_relative "cli/commands/session_list"
 require_relative "cli/commands/session_show"
 require_relative "cli/commands/session_diff"
 require_relative "cli/commands/session_gc"
+require_relative "cli/commands/compare"
 require_relative "cli/commands/run"
 
 class Evilution::CLI

--- a/lib/evilution/cli/commands/compare.rb
+++ b/lib/evilution/cli/commands/compare.rb
@@ -15,7 +15,7 @@ class Evilution::CLI::Commands::Compare < Evilution::CLI::Command
 
   def perform
     paths = resolve_paths
-    raise Evilution::ConfigError, "two file paths required for compare" unless paths.length == 2
+    raise Evilution::ConfigError, "exactly two file paths required for compare" unless paths.length == 2
 
     payload = ROLES.zip(paths).to_h { |role, path| [role, load_and_normalize(path)] }
     @stdout.puts JSON.generate(payload)
@@ -24,10 +24,14 @@ class Evilution::CLI::Commands::Compare < Evilution::CLI::Command
 
   # Flags bind to roles (--against -> slot 0, --current -> slot 1);
   # positional @files fill whatever role the flags didn't claim, in order.
+  # Extra positional args after both slots are filled are a user error.
   def resolve_paths
     positional = @files.dup
     against = @options[:against] || positional.shift
     current = @options[:current] || positional.shift
+
+    raise Evilution::ConfigError, "exactly two file paths required for compare" unless positional.empty?
+
     [against, current].compact
   end
 

--- a/lib/evilution/cli/commands/compare.rb
+++ b/lib/evilution/cli/commands/compare.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "../commands"
+require_relative "../command"
+require_relative "../dispatcher"
+require_relative "../../compare"
+require_relative "../../compare/detector"
+require_relative "../../compare/normalizer"
+
+class Evilution::CLI::Commands::Compare < Evilution::CLI::Command
+  ROLES = %i[against current].freeze
+
+  private
+
+  def perform
+    paths = resolve_paths
+    raise Evilution::ConfigError, "two file paths required for compare" unless paths.length == 2
+
+    payload = ROLES.zip(paths).to_h { |role, path| [role, load_and_normalize(path)] }
+    @stdout.puts JSON.generate(payload)
+    0
+  end
+
+  # Flags bind to roles (--against -> slot 0, --current -> slot 1);
+  # positional @files fill whatever role the flags didn't claim, in order.
+  def resolve_paths
+    positional = @files.dup
+    against = @options[:against] || positional.shift
+    current = @options[:current] || positional.shift
+    [against, current].compact
+  end
+
+  def load_and_normalize(path)
+    raise Evilution::Error, "file not found: #{path}" unless File.exist?(path)
+
+    json = JSON.parse(File.read(path))
+    tool = Evilution::Compare::Detector.call(json)
+    records = normalize(json, tool)
+    { path: path, tool: tool.to_s, records: records.map { |r| record_to_hash(r) } }
+  rescue ::JSON::ParserError => e
+    raise Evilution::Error, "invalid JSON in #{path}: #{e.message}"
+  rescue Evilution::Compare::InvalidInput => e
+    raise Evilution::Error, "#{path}: #{e.message}"
+  rescue SystemCallError => e
+    raise Evilution::Error, e.message
+  end
+
+  def normalize(json, tool)
+    normalizer = Evilution::Compare::Normalizer.new
+    case tool
+    when :mutant    then normalizer.from_mutant(json)
+    when :evilution then normalizer.from_evilution(json)
+    end
+  end
+
+  # Data#to_h keeps symbol values for :source and :status, which
+  # JSON.generate would reject. Stringify them for machine-friendly output.
+  def record_to_hash(record)
+    h = record.to_h
+    h[:source] = h[:source].to_s
+    h[:status] = h[:status].to_s
+    h
+  end
+end
+
+Evilution::CLI::Dispatcher.register(:compare, Evilution::CLI::Commands::Compare)

--- a/lib/evilution/cli/parser/command_extractor.rb
+++ b/lib/evilution/cli/parser/command_extractor.rb
@@ -5,7 +5,8 @@ class Evilution::CLI::Parser::CommandExtractor
     "version" => :version,
     "init" => :init,
     "mcp" => :mcp,
-    "subjects" => :subjects
+    "subjects" => :subjects,
+    "compare" => :compare
   }.freeze
 
   SESSION_SUBCOMMANDS = {

--- a/lib/evilution/cli/parser/options_builder.rb
+++ b/lib/evilution/cli/parser/options_builder.rb
@@ -23,6 +23,7 @@ class Evilution::CLI::Parser::OptionsBuilder
       add_flag_options(opts)
       add_extra_flag_options(opts)
       add_session_options(opts)
+      add_compare_options(opts)
     end
   end
 
@@ -33,7 +34,7 @@ class Evilution::CLI::Parser::OptionsBuilder
     opts.separator "Line-range targeting: lib/foo.rb:15-30, lib/foo.rb:15, lib/foo.rb:15-"
     opts.separator ""
     opts.separator "Commands: run (default), init, session {list,show,diff,gc}, subjects, tests {list},"
-    opts.separator "         util {mutation}, environment {show}, mcp, version"
+    opts.separator "         util {mutation}, environment {show}, compare, mcp, version"
     opts.separator ""
     opts.separator "Options:"
   end
@@ -103,6 +104,15 @@ class Evilution::CLI::Parser::OptionsBuilder
     opts.on("--since DATE", "Show sessions since DATE (YYYY-MM-DD)") { |d| @options[:since] = d }
     opts.on("--older-than DURATION", "Delete sessions older than DURATION (e.g., 30d, 24h, 1w)") do |d|
       @options[:older_than] = d
+    end
+  end
+
+  def add_compare_options(opts)
+    opts.on("--against PATH", "Prior mutation run to compare against (used with `compare` command)") do |p|
+      @options[:against] = p
+    end
+    opts.on("--current PATH", "Current mutation run to compare (used with `compare` command)") do |p|
+      @options[:current] = p
     end
   end
 

--- a/lib/evilution/compare/detector.rb
+++ b/lib/evilution/compare/detector.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 require_relative "../compare"
+require_relative "normalizer"
 
 module Evilution::Compare::Detector
-  EVILUTION_BUCKETS = %w[killed survived timed_out errors neutral equivalent unresolved unparseable].freeze
-
   module_function
 
   def call(json)
     raise Evilution::Compare::InvalidInput, "expected Hash, got #{json.class}" unless json.is_a?(Hash)
 
     mutant = json.key?("subject_results")
-    evilution = json.key?("summary") && EVILUTION_BUCKETS.any? { |k| json.key?(k) }
+    evilution = json.key?("summary") && Evilution::Compare::Normalizer::EVILUTION_BUCKETS.any? { |k| json.key?(k) }
 
     raise Evilution::Compare::InvalidInput, "ambiguous JSON shape - both mutant and evilution markers present" if mutant && evilution
     return :mutant if mutant

--- a/lib/evilution/compare/detector.rb
+++ b/lib/evilution/compare/detector.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../compare"
+
+module Evilution::Compare::Detector
+  EVILUTION_BUCKETS = %w[killed survived timed_out errors neutral equivalent unresolved unparseable].freeze
+
+  module_function
+
+  def call(json)
+    raise Evilution::Compare::InvalidInput, "expected Hash, got #{json.class}" unless json.is_a?(Hash)
+
+    mutant = json.key?("subject_results")
+    evilution = json.key?("summary") && EVILUTION_BUCKETS.any? { |k| json.key?(k) }
+
+    raise Evilution::Compare::InvalidInput, "ambiguous JSON shape - both mutant and evilution markers present" if mutant && evilution
+    return :mutant if mutant
+    return :evilution if evilution
+
+    raise Evilution::Compare::InvalidInput, "cannot detect tool from JSON shape"
+  end
+end

--- a/spec/evilution/cli/commands/compare_spec.rb
+++ b/spec/evilution/cli/commands/compare_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "json"
+require "stringio"
+require "tempfile"
+require "evilution/cli/commands/compare"
+require "evilution/cli/parsed_args"
+
+RSpec.describe Evilution::CLI::Commands::Compare do
+  let(:out) { StringIO.new }
+  let(:err) { StringIO.new }
+  let(:fixture_dir) { File.expand_path("../../../support/fixtures/compare", __dir__) }
+  let(:mutant_path) { "#{fixture_dir}/mutant.json" }
+  let(:evilution_path) { "#{fixture_dir}/evilution.json" }
+
+  def parsed(files: [], options: {})
+    Evilution::CLI::ParsedArgs.new(command: :compare, files: files, options: options)
+  end
+
+  def run_with(files: [], options: {})
+    described_class.new(parsed(files: files, options: options), stdout: out, stderr: err).call
+  end
+
+  describe "path slot resolution" do
+    it "maps two positional files to against/current in order" do
+      result = run_with(files: [mutant_path, evilution_path])
+      expect(result.exit_code).to eq(0)
+
+      payload = JSON.parse(out.string)
+      expect(payload["against"]["path"]).to eq(mutant_path)
+      expect(payload["current"]["path"]).to eq(evilution_path)
+    end
+
+    it "uses --against and --current when both flags given" do
+      result = run_with(
+        files: [],
+        options: { against: mutant_path, current: evilution_path }
+      )
+      expect(result.exit_code).to eq(0)
+
+      payload = JSON.parse(out.string)
+      expect(payload["against"]["path"]).to eq(mutant_path)
+      expect(payload["current"]["path"]).to eq(evilution_path)
+    end
+
+    it "fills missing current slot from positional when only --against given" do
+      result = run_with(
+        files: [evilution_path],
+        options: { against: mutant_path }
+      )
+      expect(result.exit_code).to eq(0)
+
+      payload = JSON.parse(out.string)
+      expect(payload["against"]["path"]).to eq(mutant_path)
+      expect(payload["current"]["path"]).to eq(evilution_path)
+    end
+
+    it "fills missing against slot from positional when only --current given" do
+      result = run_with(
+        files: [mutant_path],
+        options: { current: evilution_path }
+      )
+      expect(result.exit_code).to eq(0)
+
+      payload = JSON.parse(out.string)
+      expect(payload["against"]["path"]).to eq(mutant_path)
+      expect(payload["current"]["path"]).to eq(evilution_path)
+    end
+  end
+
+  describe "end-to-end with fixtures" do
+    it "emits JSON with normalized records from both tools" do
+      result = run_with(files: [mutant_path, evilution_path])
+      expect(result.exit_code).to eq(0)
+
+      payload = JSON.parse(out.string)
+      expect(payload.keys).to match_array(%w[against current])
+
+      expect(payload["against"]["tool"]).to eq("mutant")
+      expect(payload["against"]["path"]).to eq(mutant_path)
+      expect(payload["against"]["records"].size).to eq(4)
+
+      expect(payload["current"]["tool"]).to eq("evilution")
+      expect(payload["current"]["path"]).to eq(evilution_path)
+      expect(payload["current"]["records"].size).to eq(4)
+    end
+
+    it "produces matching fingerprints for equivalent mutations" do
+      run_with(files: [mutant_path, evilution_path])
+
+      payload = JSON.parse(out.string)
+      mutant_fps = payload["against"]["records"].map { |r| r["fingerprint"] }.sort
+      evo_fps = payload["current"]["records"].map { |r| r["fingerprint"] }.sort
+      expect(mutant_fps).to eq(evo_fps)
+    end
+
+    it "serializes symbol status and source fields as strings" do
+      run_with(files: [mutant_path, evilution_path])
+
+      payload = JSON.parse(out.string)
+      mutant_records = payload["against"]["records"]
+      evo_records = payload["current"]["records"]
+
+      expect(mutant_records.map { |r| r["source"] }.uniq).to eq(["mutant"])
+      expect(evo_records.map { |r| r["source"] }.uniq).to eq(["evilution"])
+
+      evo_statuses = evo_records.map { |r| r["status"] }
+      expect(evo_statuses).to all(be_a(String))
+      expect(evo_statuses.sort).to eq(%w[killed killed survived timeout])
+    end
+
+    it "emits single-line JSON (no pretty-print)" do
+      run_with(files: [mutant_path, evilution_path])
+      # @stdout.puts appends exactly one trailing newline; rest must be single line.
+      expect(out.string.count("\n")).to eq(1)
+    end
+  end
+
+  describe "error handling" do
+    it "returns exit 2 with helpful message for missing files" do
+      result = run_with(files: ["nope/missing.json", evilution_path])
+      expect(result.exit_code).to eq(2)
+      expect(result.error).to be_a(Evilution::Error)
+      expect(result.error.message).to include("file not found", "nope/missing.json")
+    end
+
+    it "returns exit 2 with JSON parse error for malformed input" do
+      Tempfile.create(["bad", ".json"]) do |f|
+        f.write("not json{")
+        f.flush
+
+        result = run_with(files: [f.path, evilution_path])
+        expect(result.exit_code).to eq(2)
+        expect(result.error).to be_a(Evilution::Error)
+        expect(result.error.message).to include("invalid JSON", f.path)
+      end
+    end
+
+    it "returns exit 2 with InvalidInput message when detector cannot classify" do
+      Tempfile.create(["ambig", ".json"]) do |f|
+        f.write(JSON.generate({ "unknown" => true }))
+        f.flush
+
+        result = run_with(files: [f.path, evilution_path])
+        expect(result.exit_code).to eq(2)
+        expect(result.error).to be_a(Evilution::Error)
+        expect(result.error.message).to include(f.path)
+        expect(result.error.message).to include("cannot detect tool")
+      end
+    end
+  end
+
+  describe "wrong arg count" do
+    it "returns exit 2 with ConfigError when no paths at all" do
+      result = run_with(files: [])
+      expect(result.exit_code).to eq(2)
+      expect(result.error).to be_a(Evilution::ConfigError)
+      expect(result.error.message).to eq("two file paths required for compare")
+    end
+
+    it "returns exit 2 when only one path given" do
+      result = run_with(files: ["only.json"])
+      expect(result.exit_code).to eq(2)
+      expect(result.error).to be_a(Evilution::ConfigError)
+    end
+  end
+
+  it "is registered with the dispatcher under :compare" do
+    require "evilution/cli/dispatcher"
+    expect(Evilution::CLI::Dispatcher.registered?(:compare)).to be(true)
+    expect(Evilution::CLI::Dispatcher.lookup(:compare)).to eq(described_class)
+  end
+end

--- a/spec/evilution/cli/commands/compare_spec.rb
+++ b/spec/evilution/cli/commands/compare_spec.rb
@@ -155,11 +155,27 @@ RSpec.describe Evilution::CLI::Commands::Compare do
       result = run_with(files: [])
       expect(result.exit_code).to eq(2)
       expect(result.error).to be_a(Evilution::ConfigError)
-      expect(result.error.message).to eq("two file paths required for compare")
+      expect(result.error.message).to eq("exactly two file paths required for compare")
     end
 
     it "returns exit 2 when only one path given" do
       result = run_with(files: ["only.json"])
+      expect(result.exit_code).to eq(2)
+      expect(result.error).to be_a(Evilution::ConfigError)
+    end
+
+    it "returns exit 2 when more than two positional paths given" do
+      result = run_with(files: %w[a.json b.json c.json])
+      expect(result.exit_code).to eq(2)
+      expect(result.error).to be_a(Evilution::ConfigError)
+      expect(result.error.message).to eq("exactly two file paths required for compare")
+    end
+
+    it "returns exit 2 when flags plus extra positional overflow slots" do
+      result = run_with(
+        files: ["extra.json"],
+        options: { against: "a.json", current: "b.json" }
+      )
       expect(result.exit_code).to eq(2)
       expect(result.error).to be_a(Evilution::ConfigError)
     end

--- a/spec/evilution/cli/parser/command_extractor_spec.rb
+++ b/spec/evilution/cli/parser/command_extractor_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe Evilution::CLI::Parser::CommandExtractor do
       expect(extract(["subjects"]).command).to eq(:subjects)
     end
 
+    it "extracts 'compare' as :compare" do
+      result = described_class.call(["compare", "a.json", "b.json"])
+      expect(result.command).to eq(:compare)
+      expect(result.remaining_argv).to eq(["a.json", "b.json"])
+    end
+
     it "treats explicit 'run' as :run" do
       expect(extract(["run"]).command).to eq(:run)
     end

--- a/spec/evilution/cli/parser/options_builder_spec.rb
+++ b/spec/evilution/cli/parser/options_builder_spec.rb
@@ -96,4 +96,14 @@ RSpec.describe Evilution::CLI::Parser::OptionsBuilder do
     options, = parse(["--example-targeting-fallback", "unresolved"])
     expect(options[:example_targeting_fallback]).to eq("unresolved")
   end
+
+  it "captures --against path" do
+    options, = parse(["--against=prior.json"])
+    expect(options[:against]).to eq("prior.json")
+  end
+
+  it "captures --current path" do
+    options, = parse(["--current=curr.json"])
+    expect(options[:current]).to eq("curr.json")
+  end
 end

--- a/spec/evilution/cli_spec.rb
+++ b/spec/evilution/cli_spec.rb
@@ -1260,7 +1260,7 @@ RSpec.describe Evilution::CLI do
       cli = described_class.new(["compare"])
       stderr = capture_stderr { expect(cli.call).to eq(2) }
 
-      expect(stderr).to include("two file paths required for compare")
+      expect(stderr).to include("exactly two file paths required for compare")
     end
 
     it "returns exit code 2 when a file does not exist" do

--- a/spec/evilution/cli_spec.rb
+++ b/spec/evilution/cli_spec.rb
@@ -1231,4 +1231,43 @@ RSpec.describe Evilution::CLI do
       expect(output).to include("diff")
     end
   end
+
+  describe "compare command" do
+    let(:fixture_dir) { File.expand_path("../support/fixtures/compare", __dir__) }
+    let(:mutant_path) { "#{fixture_dir}/mutant.json" }
+    let(:evilution_path) { "#{fixture_dir}/evilution.json" }
+
+    it "returns exit code 0 and emits JSON with both tool payloads (positional)" do
+      cli = described_class.new(["compare", mutant_path, evilution_path])
+      output = capture_stdout { expect(cli.call).to eq(0) }
+      parsed = JSON.parse(output)
+
+      expect(parsed.keys).to match_array(%w[against current])
+      expect(parsed["against"]["tool"]).to eq("mutant")
+      expect(parsed["current"]["tool"]).to eq("evilution")
+    end
+
+    it "respects --against and --current flags" do
+      cli = described_class.new(["compare", "--against", mutant_path, "--current", evilution_path])
+      output = capture_stdout { expect(cli.call).to eq(0) }
+      parsed = JSON.parse(output)
+
+      expect(parsed["against"]["path"]).to eq(mutant_path)
+      expect(parsed["current"]["path"]).to eq(evilution_path)
+    end
+
+    it "returns exit code 2 with message when fewer than two files given" do
+      cli = described_class.new(["compare"])
+      stderr = capture_stderr { expect(cli.call).to eq(2) }
+
+      expect(stderr).to include("two file paths required for compare")
+    end
+
+    it "returns exit code 2 when a file does not exist" do
+      cli = described_class.new(["compare", "nope/missing.json", evilution_path])
+      stderr = capture_stderr { expect(cli.call).to eq(2) }
+
+      expect(stderr).to include("file not found")
+    end
+  end
 end

--- a/spec/evilution/compare/detector_spec.rb
+++ b/spec/evilution/compare/detector_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "evilution/compare/detector"
+
+RSpec.describe Evilution::Compare::Detector do
+  describe ".call" do
+    it "returns :mutant for JSON with subject_results" do
+      expect(described_class.call({ "subject_results" => [] })).to eq(:mutant)
+    end
+
+    it "returns :evilution for JSON with summary and status buckets" do
+      json = { "summary" => { "total" => 0 }, "killed" => [], "survived" => [] }
+      expect(described_class.call(json)).to eq(:evilution)
+    end
+
+    it "returns :evilution when only one status bucket is present" do
+      json = { "summary" => {}, "survived" => [] }
+      expect(described_class.call(json)).to eq(:evilution)
+    end
+
+    it "raises InvalidInput on ambiguous shape (both markers present)" do
+      json = { "subject_results" => [], "summary" => {}, "killed" => [] }
+      expect { described_class.call(json) }
+        .to raise_error(Evilution::Compare::InvalidInput, /ambiguous/)
+    end
+
+    it "raises InvalidInput when shape cannot be detected" do
+      expect { described_class.call({ "unknown" => "stuff" }) }
+        .to raise_error(Evilution::Compare::InvalidInput, /cannot detect/)
+    end
+
+    it "raises InvalidInput on non-Hash input" do
+      expect { described_class.call([]) }
+        .to raise_error(Evilution::Compare::InvalidInput, /Hash/)
+    end
+  end
+end


### PR DESCRIPTION
- Implemented the Compare command in Evilution::CLI::Commands::Compare.
- Registered the compare command with the dispatcher.
- Updated command extractor to recognize the compare command.
- Enhanced options builder to include flags for --against and --current.
- Created detector for identifying JSON structure from comparison files.
- Added tests for compare command and detector functionality.