### PR TITLE
841: Add validators for Evilution configuration options

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,6 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 150
   Exclude:
-    - "lib/evilution/config.rb"
     - "lib/evilution/mcp/info_tool.rb"
     - "lib/evilution/parallel/work_queue.rb"
     - "lib/evilution/integration/rspec.rb"

--- a/lib/evilution/config.rb
+++ b/lib/evilution/config.rb
@@ -8,39 +8,16 @@ class Evilution::Config
   CONFIG_FILES = %w[.evilution.yml config/evilution.yml].freeze
 
   DEFAULTS = {
-    timeout: 30,
-    format: :text,
-    target: nil,
-    min_score: 0.0,
-    integration: :rspec,
-    verbose: false,
-    quiet: false,
-    jobs: 1,
-    fail_fast: nil,
-    baseline: true,
-    isolation: :auto,
-    incremental: false,
-    suggest_tests: false,
-    progress: true,
-    save_session: false,
-    line_ranges: {},
-    spec_files: [],
-    ignore_patterns: [],
-    show_disabled: false,
-    baseline_session: nil,
-    skip_heredoc_literals: false,
-    related_specs_heuristic: false,
-    fallback_to_full_suite: false,
-    preload: nil,
-    spec_mappings: {},
-    spec_pattern: nil,
-    example_targeting: true,
+    timeout: 30, format: :text, target: nil, min_score: 0.0, integration: :rspec,
+    verbose: false, quiet: false, jobs: 1, fail_fast: nil, baseline: true,
+    isolation: :auto, incremental: false, suggest_tests: false, progress: true,
+    save_session: false, line_ranges: {}, spec_files: [], ignore_patterns: [],
+    show_disabled: false, baseline_session: nil, skip_heredoc_literals: false,
+    related_specs_heuristic: false, fallback_to_full_suite: false, preload: nil,
+    spec_mappings: {}, spec_pattern: nil, example_targeting: true,
     example_targeting_fallback: :full_file,
     example_targeting_cache: { max_files: 50, max_blocks: 10_000 }
   }.freeze
-
-  EXAMPLE_TARGETING_FALLBACKS = %i[full_file unresolved].freeze
-  private_constant :EXAMPLE_TARGETING_FALLBACKS
 
   attr_reader :target_files, :timeout, :format,
               :target, :min_score, :integration, :verbose, :quiet,
@@ -53,9 +30,8 @@ class Evilution::Config
               :spec_selector
 
   def initialize(**options)
-    file_options = options.delete(:skip_config_file) ? {} : load_config_file
-    env_options = load_env_options
-    merged = DEFAULTS.merge(file_options).merge(env_options).merge(options)
+    skip_file = options.delete(:skip_config_file) ? true : false
+    merged = Sources.merge(explicit: options, skip_file: skip_file)
     assign_attributes(merged)
     freeze
   end
@@ -125,18 +101,7 @@ class Evilution::Config
   end
 
   def self.file_options
-    CONFIG_FILES.each do |path|
-      next unless File.exist?(path)
-
-      data = YAML.safe_load_file(path, symbolize_names: true)
-      return data.is_a?(Hash) ? data : {}
-    rescue Psych::SyntaxError, Psych::DisallowedClass => e
-      raise Evilution::ConfigError.new("failed to parse config file #{path}: #{e.message}", file: path)
-    rescue SystemCallError => e
-      raise Evilution::ConfigError.new("cannot read config file #{path}: #{e.message}", file: path)
-    end
-
-    {}
+    FileLoader.load
   end
 
   # Generates a default config file template.
@@ -221,234 +186,79 @@ class Evilution::Config
 
   private
 
-  def validate_fail_fast(value)
-    return nil if value.nil?
-
-    value = Integer(value)
-    raise Evilution::ConfigError, "fail_fast must be a positive integer, got #{value}" unless value >= 1
-
-    value
-  rescue ::ArgumentError, ::TypeError
-    raise Evilution::ConfigError, "fail_fast must be a positive integer, got #{value.inspect}"
-  end
-
-  def assign_attributes(merged) # rubocop:disable Metrics/AbcSize
-    @target_files = Array(merged[:target_files])
-    @timeout = merged[:timeout]
-    @format = merged[:format].to_sym
-    @target = merged[:target]
-    @min_score = merged[:min_score].to_f
-    @integration = validate_integration(merged[:integration])
-    @verbose = merged[:verbose]
-    @quiet = merged[:quiet]
-    @jobs = validate_jobs(merged[:jobs])
-    @fail_fast = validate_fail_fast(merged[:fail_fast])
-    @baseline = merged[:baseline]
-    @isolation = validate_isolation(merged[:isolation])
-    @incremental = merged[:incremental]
-    @suggest_tests = merged[:suggest_tests]
-    @progress = merged[:progress]
-    @save_session = merged[:save_session]
-    @line_ranges = merged[:line_ranges] || {}
-    @spec_files = Array(merged[:spec_files])
-    @ignore_patterns = validate_ignore_patterns(merged[:ignore_patterns])
-    @show_disabled = merged[:show_disabled]
-    @baseline_session = merged[:baseline_session]
-    @skip_heredoc_literals = merged[:skip_heredoc_literals]
-    @related_specs_heuristic = merged[:related_specs_heuristic]
-    @fallback_to_full_suite = merged[:fallback_to_full_suite]
-    @hooks = validate_hooks(merged[:hooks])
-    @preload = validate_preload(merged[:preload])
-    @spec_mappings = validate_spec_mappings(merged[:spec_mappings])
-    @spec_pattern = validate_spec_pattern(merged[:spec_pattern])
+  def assign_attributes(merged)
+    assign_simple_attributes(merged)
+    assign_validated_attributes(merged)
     assign_example_targeting(merged)
-    @spec_selector = build_spec_selector
-  end
-
-  def assign_example_targeting(merged)
-    @example_targeting = merged[:example_targeting] ? true : false
-    @example_targeting_fallback = validate_example_targeting_fallback(merged[:example_targeting_fallback])
-    @example_targeting_cache = validate_example_targeting_cache(merged[:example_targeting_cache])
-  end
-
-  def build_spec_selector
-    Evilution::SpecSelector.new(
+    @spec_selector = Builders::SpecSelector.call(
       spec_files: @spec_files,
       spec_mappings: @spec_mappings,
       spec_pattern: @spec_pattern,
-      spec_resolver: build_spec_resolver
+      integration: @integration
     )
   end
 
-  def build_spec_resolver
-    case @integration
-    when :minitest
-      Evilution::SpecResolver.new(test_dir: "test", test_suffix: "_test.rb", request_dir: "integration")
-    else
-      Evilution::SpecResolver.new
-    end
+  def assign_simple_attributes(merged)
+    @target_files            = Array(merged[:target_files])
+    @timeout                 = merged[:timeout]
+    @format                  = merged[:format].to_sym
+    @target                  = merged[:target]
+    @min_score               = merged[:min_score].to_f
+    @verbose                 = merged[:verbose]
+    @quiet                   = merged[:quiet]
+    @baseline                = merged[:baseline]
+    @incremental             = merged[:incremental]
+    @suggest_tests           = merged[:suggest_tests]
+    @progress                = merged[:progress]
+    @save_session            = merged[:save_session]
+    @line_ranges             = merged[:line_ranges] || {}
+    @spec_files              = Array(merged[:spec_files])
+    @show_disabled           = merged[:show_disabled]
+    @baseline_session        = merged[:baseline_session]
+    @skip_heredoc_literals   = merged[:skip_heredoc_literals]
+    @related_specs_heuristic = merged[:related_specs_heuristic]
+    @fallback_to_full_suite  = merged[:fallback_to_full_suite]
   end
 
-  def validate_spec_mappings(value)
-    return {} if value.nil?
-
-    raise Evilution::ConfigError, "spec_mappings must be a Hash, got #{value.class}" unless value.is_a?(Hash)
-
-    normalized = value.each_with_object({}) do |(source, specs), acc|
-      key = normalize_spec_mappings_key(source)
-      acc[key] = normalize_spec_mappings_value(key, specs)
-    end
-
-    warn_missing_spec_mappings(normalized)
-    normalized
+  def assign_validated_attributes(merged)
+    @integration     = Validators::Integration.call(merged[:integration])
+    @jobs            = Validators::Jobs.call(merged[:jobs])
+    @fail_fast       = Validators::FailFast.call(merged[:fail_fast])
+    @isolation       = Validators::Isolation.call(merged[:isolation])
+    @ignore_patterns = Validators::IgnorePatterns.call(merged[:ignore_patterns])
+    @hooks           = Validators::Hooks.call(merged[:hooks])
+    @preload         = Validators::Preload.call(merged[:preload])
+    @spec_mappings   = Validators::SpecMappings.call(merged[:spec_mappings])
+    @spec_pattern    = Validators::SpecPattern.call(merged[:spec_pattern])
   end
 
-  def normalize_spec_mappings_key(source)
-    key = source.to_s
-    key = key.delete_prefix("#{Dir.pwd}/") if key.start_with?("/")
-    key.delete_prefix("./")
-  end
-
-  def normalize_spec_mappings_value(source, specs)
-    case specs
-    when String then [specs]
-    when Array
-      specs.each do |entry|
-        unless entry.is_a?(String)
-          raise Evilution::ConfigError,
-                "spec_mappings[#{source.inspect}] entries must be string paths, got #{entry.class}"
-        end
-      end
-      specs
-    else
-      raise Evilution::ConfigError,
-            "spec_mappings[#{source.inspect}] must be a string or array of strings, got #{specs.class}"
-    end
-  end
-
-  def warn_missing_spec_mappings(mappings)
-    mappings.each do |source, specs|
-      specs.each do |spec_path|
-        next if File.exist?(spec_path)
-
-        warn "[evilution] spec_mappings[#{source.inspect}]: #{spec_path} not found, skipping"
-      end
-    end
-  end
-
-  def validate_spec_pattern(value)
-    return nil if value.nil?
-    return value if value.is_a?(String)
-
-    raise Evilution::ConfigError, "spec_pattern must be nil or a String glob, got #{value.class}"
-  end
-
-  def validate_preload(value)
-    return nil if value.nil?
-    return false if value == false
-    return value if value.is_a?(String)
-
-    raise Evilution::ConfigError, "preload must be nil, false, or a String path, got #{value.inspect}"
-  end
-
-  def validate_integration(value)
-    raise Evilution::ConfigError, "integration must be rspec or minitest, got nil" if value.nil?
-
-    value = value.to_sym
-    unless %i[rspec minitest].include?(value)
-      raise Evilution::ConfigError,
-            "integration must be rspec or minitest, got #{value.inspect}"
-    end
-
-    value
-  end
-
-  def validate_isolation(value)
-    raise Evilution::ConfigError, "isolation must be auto, fork, or in_process, got nil" if value.nil?
-
-    value = value.to_sym
-    raise Evilution::ConfigError, "isolation must be auto, fork, or in_process, got #{value.inspect}" unless %i[auto fork
-                                                                                                                in_process].include?(value)
-
-    value
-  end
-
-  def validate_jobs(value)
-    raise Evilution::ConfigError, "jobs must be a positive integer, got #{value.inspect}" if value.is_a?(Float)
-
-    value = Integer(value)
-    raise Evilution::ConfigError, "jobs must be a positive integer, got #{value}" unless value >= 1
-
-    value
-  rescue ::ArgumentError, ::TypeError
-    raise Evilution::ConfigError, "jobs must be a positive integer, got #{value.inspect}"
-  end
-
-  def validate_ignore_patterns(value)
-    patterns = Array(value)
-    patterns.each do |pattern|
-      unless pattern.is_a?(String)
-        raise Evilution::ConfigError,
-              "ignore_patterns must be an array of strings, got #{pattern.class} (#{pattern.inspect})"
-      end
-    end
-    patterns
-  end
-
-  def validate_example_targeting_fallback(value)
-    unless value.is_a?(String) || value.is_a?(Symbol)
-      raise Evilution::ConfigError,
-            "example_targeting_fallback must be full_file or unresolved, got #{value.inspect}"
-    end
-
-    sym = value.to_sym
-    unless EXAMPLE_TARGETING_FALLBACKS.include?(sym)
-      raise Evilution::ConfigError,
-            "example_targeting_fallback must be full_file or unresolved, got #{sym.inspect}"
-    end
-
-    sym
-  end
-
-  def validate_example_targeting_cache(value)
-    raise Evilution::ConfigError, "example_targeting_cache must be a Hash, got #{value.class}" unless value.is_a?(Hash)
-
-    normalized = value.each_with_object({}) do |(k, v), acc|
-      unless k.is_a?(String) || k.is_a?(Symbol)
-        raise Evilution::ConfigError,
-              "example_targeting_cache keys must be Strings or Symbols, got #{k.inspect}"
-      end
-      acc[k.to_sym] = v
-    end
-    merged = DEFAULTS[:example_targeting_cache].merge(normalized)
-    validate_positive_int!(merged, :max_files)
-    validate_positive_int!(merged, :max_blocks)
-    merged
-  end
-
-  def validate_positive_int!(cache, key)
-    v = cache[key]
-    return if v.is_a?(Integer) && v >= 1
-
-    raise Evilution::ConfigError,
-          "example_targeting_cache.#{key} must be a positive integer, got #{v.inspect}"
-  end
-
-  def load_env_options
-    opts = {}
-    val = ENV.fetch("EV_DISABLE_EXAMPLE_TARGETING", nil)
-    opts[:example_targeting] = false if val && !val.empty? && val != "0"
-    opts
-  end
-
-  def validate_hooks(value)
-    return {} if value.nil?
-    raise Evilution::ConfigError, "hooks must be a mapping of event names to file paths, got #{value.class}" unless value.is_a?(Hash)
-
-    value
+  def assign_example_targeting(merged)
+    @example_targeting          = merged[:example_targeting] ? true : false
+    @example_targeting_fallback = Validators::ExampleTargetingFallback.call(merged[:example_targeting_fallback])
+    @example_targeting_cache    = Validators::ExampleTargetingCache.call(merged[:example_targeting_cache])
   end
 
   def load_config_file
     self.class.file_options
   end
 end
+
+require_relative "config/file_loader"
+require_relative "config/env_loader"
+require_relative "config/sources"
+require_relative "config/validators"
+require_relative "config/validators/base"
+require_relative "config/validators/integration"
+require_relative "config/validators/isolation"
+require_relative "config/validators/jobs"
+require_relative "config/validators/fail_fast"
+require_relative "config/validators/preload"
+require_relative "config/validators/hooks"
+require_relative "config/validators/ignore_patterns"
+require_relative "config/validators/spec_pattern"
+require_relative "config/validators/spec_mappings"
+require_relative "config/validators/example_targeting_fallback"
+require_relative "config/validators/example_targeting_cache"
+require_relative "config/builders"
+require_relative "config/builders/spec_resolver"
+require_relative "config/builders/spec_selector"

--- a/lib/evilution/config.rb
+++ b/lib/evilution/config.rb
@@ -237,10 +237,6 @@ class Evilution::Config
     @example_targeting_fallback = Validators::ExampleTargetingFallback.call(merged[:example_targeting_fallback])
     @example_targeting_cache    = Validators::ExampleTargetingCache.call(merged[:example_targeting_cache])
   end
-
-  def load_config_file
-    self.class.file_options
-  end
 end
 
 require_relative "config/file_loader"

--- a/lib/evilution/config/builders.rb
+++ b/lib/evilution/config/builders.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Evilution::Config::Builders
+end

--- a/lib/evilution/config/builders/spec_resolver.rb
+++ b/lib/evilution/config/builders/spec_resolver.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../builders"
+require_relative "../../spec_resolver"
+
+class Evilution::Config::Builders::SpecResolver
+  def self.call(integration:)
+    case integration
+    when :minitest
+      Evilution::SpecResolver.new(test_dir: "test", test_suffix: "_test.rb", request_dir: "integration")
+    else
+      Evilution::SpecResolver.new
+    end
+  end
+end

--- a/lib/evilution/config/builders/spec_selector.rb
+++ b/lib/evilution/config/builders/spec_selector.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../builders"
+require_relative "spec_resolver"
+require_relative "../../spec_selector"
+
+class Evilution::Config::Builders::SpecSelector
+  def self.call(spec_files:, spec_mappings:, spec_pattern:, integration:)
+    Evilution::SpecSelector.new(
+      spec_files: spec_files,
+      spec_mappings: spec_mappings,
+      spec_pattern: spec_pattern,
+      spec_resolver: Evilution::Config::Builders::SpecResolver.call(integration: integration)
+    )
+  end
+end

--- a/lib/evilution/config/env_loader.rb
+++ b/lib/evilution/config/env_loader.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Evilution::Config::EnvLoader
+  module_function
+
+  def load
+    opts = {}
+    val = ENV.fetch("EV_DISABLE_EXAMPLE_TARGETING", nil)
+    opts[:example_targeting] = false if val && !val.empty? && val != "0"
+    opts
+  end
+end

--- a/lib/evilution/config/file_loader.rb
+++ b/lib/evilution/config/file_loader.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+module Evilution::Config::FileLoader
+  module_function
+
+  def load
+    Evilution::Config::CONFIG_FILES.each do |path|
+      next unless File.exist?(path)
+
+      data = YAML.safe_load_file(path, symbolize_names: true)
+      return data.is_a?(Hash) ? data : {}
+    rescue Psych::SyntaxError, Psych::DisallowedClass => e
+      raise Evilution::ConfigError.new("failed to parse config file #{path}: #{e.message}", file: path)
+    rescue SystemCallError => e
+      raise Evilution::ConfigError.new("cannot read config file #{path}: #{e.message}", file: path)
+    end
+
+    {}
+  end
+end

--- a/lib/evilution/config/sources.rb
+++ b/lib/evilution/config/sources.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "file_loader"
+require_relative "env_loader"
+
+module Evilution::Config::Sources
+  module_function
+
+  def merge(explicit:, skip_file:)
+    file = skip_file ? {} : Evilution::Config::FileLoader.load
+    env  = Evilution::Config::EnvLoader.load
+    Evilution::Config::DEFAULTS.merge(file).merge(env).merge(explicit)
+  end
+end

--- a/lib/evilution/config/validators.rb
+++ b/lib/evilution/config/validators.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module Evilution::Config::Validators
+end

--- a/lib/evilution/config/validators/base.rb
+++ b/lib/evilution/config/validators/base.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative "../validators"
+
+class Evilution::Config::Validators::Base
+  def self.call(_value)
+    raise NotImplementedError
+  end
+
+  class << self
+    private
+
+    def coerce_symbol!(value, allowed:, name:)
+      raise Evilution::ConfigError, "#{name} must be #{allowed.join(" or ")}, got nil" if value.nil?
+
+      sym = value.to_sym
+      return sym if allowed.include?(sym)
+
+      raise Evilution::ConfigError, "#{name} must be #{allowed.join(" or ")}, got #{sym.inspect}"
+    end
+
+    def coerce_positive_int!(value, name:)
+      raise Evilution::ConfigError, "#{name} must be a positive integer, got #{value.inspect}" if value.is_a?(Float)
+
+      int = Integer(value)
+      raise Evilution::ConfigError, "#{name} must be a positive integer, got #{int}" unless int >= 1
+
+      int
+    rescue ::ArgumentError, ::TypeError
+      raise Evilution::ConfigError, "#{name} must be a positive integer, got #{value.inspect}"
+    end
+  end
+end

--- a/lib/evilution/config/validators/base.rb
+++ b/lib/evilution/config/validators/base.rb
@@ -13,6 +13,10 @@ class Evilution::Config::Validators::Base
     def coerce_symbol!(value, allowed:, name:)
       raise Evilution::ConfigError, "#{name} must be #{allowed.join(" or ")}, got nil" if value.nil?
 
+      unless value.is_a?(String) || value.is_a?(Symbol)
+        raise Evilution::ConfigError, "#{name} must be #{allowed.join(" or ")}, got #{value.inspect}"
+      end
+
       sym = value.to_sym
       return sym if allowed.include?(sym)
 

--- a/lib/evilution/config/validators/example_targeting_cache.rb
+++ b/lib/evilution/config/validators/example_targeting_cache.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::ExampleTargetingCache < Evilution::Config::Validators::Base
+  def self.call(value)
+    raise Evilution::ConfigError, "example_targeting_cache must be a Hash, got #{value.class}" unless value.is_a?(Hash)
+
+    normalized = normalize_keys(value)
+    merged = Evilution::Config::DEFAULTS[:example_targeting_cache].merge(normalized)
+    require_positive_int!(merged, :max_files)
+    require_positive_int!(merged, :max_blocks)
+    merged
+  end
+
+  class << self
+    private
+
+    def normalize_keys(value)
+      value.each_with_object({}) do |(k, v), acc|
+        unless k.is_a?(String) || k.is_a?(Symbol)
+          raise Evilution::ConfigError,
+                "example_targeting_cache keys must be Strings or Symbols, got #{k.inspect}"
+        end
+        acc[k.to_sym] = v
+      end
+    end
+
+    def require_positive_int!(cache, key)
+      v = cache[key]
+      return if v.is_a?(Integer) && v >= 1
+
+      raise Evilution::ConfigError,
+            "example_targeting_cache.#{key} must be a positive integer, got #{v.inspect}"
+    end
+  end
+end

--- a/lib/evilution/config/validators/example_targeting_fallback.rb
+++ b/lib/evilution/config/validators/example_targeting_fallback.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::ExampleTargetingFallback < Evilution::Config::Validators::Base
+  FALLBACKS = %i[full_file unresolved].freeze
+
+  def self.call(value)
+    unless value.is_a?(String) || value.is_a?(Symbol)
+      raise Evilution::ConfigError,
+            "example_targeting_fallback must be full_file or unresolved, got #{value.inspect}"
+    end
+
+    sym = value.to_sym
+    unless FALLBACKS.include?(sym)
+      raise Evilution::ConfigError,
+            "example_targeting_fallback must be full_file or unresolved, got #{sym.inspect}"
+    end
+
+    sym
+  end
+end

--- a/lib/evilution/config/validators/fail_fast.rb
+++ b/lib/evilution/config/validators/fail_fast.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::FailFast < Evilution::Config::Validators::Base
+  def self.call(value)
+    return nil if value.nil?
+
+    coerce_positive_int!(value, name: "fail_fast")
+  end
+end

--- a/lib/evilution/config/validators/hooks.rb
+++ b/lib/evilution/config/validators/hooks.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::Hooks < Evilution::Config::Validators::Base
+  def self.call(value)
+    return {} if value.nil?
+    raise Evilution::ConfigError, "hooks must be a mapping of event names to file paths, got #{value.class}" unless value.is_a?(Hash)
+
+    value
+  end
+end

--- a/lib/evilution/config/validators/ignore_patterns.rb
+++ b/lib/evilution/config/validators/ignore_patterns.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::IgnorePatterns < Evilution::Config::Validators::Base
+  def self.call(value)
+    patterns = Array(value)
+    patterns.each do |pattern|
+      unless pattern.is_a?(String)
+        raise Evilution::ConfigError,
+              "ignore_patterns must be an array of strings, got #{pattern.class} (#{pattern.inspect})"
+      end
+    end
+    patterns
+  end
+end

--- a/lib/evilution/config/validators/integration.rb
+++ b/lib/evilution/config/validators/integration.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::Integration < Evilution::Config::Validators::Base
+  ALLOWED = %i[rspec minitest].freeze
+
+  def self.call(value)
+    coerce_symbol!(value, allowed: ALLOWED, name: "integration")
+  end
+end

--- a/lib/evilution/config/validators/isolation.rb
+++ b/lib/evilution/config/validators/isolation.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::Isolation < Evilution::Config::Validators::Base
+  ALLOWED = %i[auto fork in_process].freeze
+  MESSAGE = "isolation must be auto, fork, or in_process"
+
+  def self.call(value)
+    raise Evilution::ConfigError, "#{MESSAGE}, got nil" if value.nil?
+
+    sym = value.to_sym
+    return sym if ALLOWED.include?(sym)
+
+    raise Evilution::ConfigError, "#{MESSAGE}, got #{sym.inspect}"
+  end
+end

--- a/lib/evilution/config/validators/isolation.rb
+++ b/lib/evilution/config/validators/isolation.rb
@@ -9,6 +9,8 @@ class Evilution::Config::Validators::Isolation < Evilution::Config::Validators::
   def self.call(value)
     raise Evilution::ConfigError, "#{MESSAGE}, got nil" if value.nil?
 
+    raise Evilution::ConfigError, "#{MESSAGE}, got #{value.inspect}" unless value.is_a?(String) || value.is_a?(Symbol)
+
     sym = value.to_sym
     return sym if ALLOWED.include?(sym)
 

--- a/lib/evilution/config/validators/jobs.rb
+++ b/lib/evilution/config/validators/jobs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::Jobs < Evilution::Config::Validators::Base
+  def self.call(value)
+    coerce_positive_int!(value, name: "jobs")
+  end
+end

--- a/lib/evilution/config/validators/preload.rb
+++ b/lib/evilution/config/validators/preload.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::Preload < Evilution::Config::Validators::Base
+  def self.call(value)
+    return nil if value.nil?
+    return false if value == false
+    return value if value.is_a?(String)
+
+    raise Evilution::ConfigError, "preload must be nil, false, or a String path, got #{value.inspect}"
+  end
+end

--- a/lib/evilution/config/validators/spec_mappings.rb
+++ b/lib/evilution/config/validators/spec_mappings.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::SpecMappings < Evilution::Config::Validators::Base
+  def self.call(value)
+    return {} if value.nil?
+
+    raise Evilution::ConfigError, "spec_mappings must be a Hash, got #{value.class}" unless value.is_a?(Hash)
+
+    normalized = value.each_with_object({}) do |(source, specs), acc|
+      key = normalize_key(source)
+      acc[key] = normalize_value(key, specs)
+    end
+
+    warn_missing(normalized)
+    normalized
+  end
+
+  class << self
+    private
+
+    def normalize_key(source)
+      key = source.to_s
+      key = key.delete_prefix("#{Dir.pwd}/") if key.start_with?("/")
+      key.delete_prefix("./")
+    end
+
+    def normalize_value(source, specs)
+      case specs
+      when String then [specs]
+      when Array
+        specs.each do |entry|
+          unless entry.is_a?(String)
+            raise Evilution::ConfigError,
+                  "spec_mappings[#{source.inspect}] entries must be string paths, got #{entry.class}"
+          end
+        end
+        specs
+      else
+        raise Evilution::ConfigError,
+              "spec_mappings[#{source.inspect}] must be a string or array of strings, got #{specs.class}"
+      end
+    end
+
+    def warn_missing(mappings)
+      mappings.each do |source, specs|
+        specs.each do |spec_path|
+          next if File.exist?(spec_path)
+
+          warn "[evilution] spec_mappings[#{source.inspect}]: #{spec_path} not found, skipping"
+        end
+      end
+    end
+  end
+end

--- a/lib/evilution/config/validators/spec_pattern.rb
+++ b/lib/evilution/config/validators/spec_pattern.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+class Evilution::Config::Validators::SpecPattern < Evilution::Config::Validators::Base
+  def self.call(value)
+    return nil if value.nil?
+    return value if value.is_a?(String)
+
+    raise Evilution::ConfigError, "spec_pattern must be nil or a String glob, got #{value.class}"
+  end
+end

--- a/spec/evilution/config/builders/spec_resolver_spec.rb
+++ b/spec/evilution/config/builders/spec_resolver_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/builders/spec_resolver"
+
+RSpec.describe Evilution::Config::Builders::SpecResolver do
+  describe ".call" do
+    it "passes no kwargs for :rspec" do
+      expect(Evilution::SpecResolver).to receive(:new).with(no_args)
+      described_class.call(integration: :rspec)
+    end
+
+    it "passes minitest-shaped kwargs for :minitest" do
+      expect(Evilution::SpecResolver).to receive(:new).with(
+        test_dir: "test", test_suffix: "_test.rb", request_dir: "integration"
+      )
+      described_class.call(integration: :minitest)
+    end
+  end
+end

--- a/spec/evilution/config/builders/spec_selector_spec.rb
+++ b/spec/evilution/config/builders/spec_selector_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/builders/spec_selector"
+
+RSpec.describe Evilution::Config::Builders::SpecSelector do
+  describe ".call" do
+    it "wires SpecSelector with a SpecResolver matching the integration" do
+      selector = described_class.call(
+        spec_files: ["spec/foo_spec.rb"],
+        spec_mappings: {},
+        spec_pattern: nil,
+        integration: :rspec
+      )
+      expect(selector).to be_a(Evilution::SpecSelector)
+    end
+
+    it "passes all kwargs through to SpecSelector.new" do
+      resolver = instance_double(Evilution::SpecResolver)
+      expect(Evilution::Config::Builders::SpecResolver).to receive(:call)
+        .with(integration: :minitest).and_return(resolver)
+      expect(Evilution::SpecSelector).to receive(:new).with(
+        spec_files: ["a"], spec_mappings: { "k" => ["v"] },
+        spec_pattern: "p", spec_resolver: resolver
+      )
+      described_class.call(
+        spec_files: ["a"], spec_mappings: { "k" => ["v"] },
+        spec_pattern: "p", integration: :minitest
+      )
+    end
+  end
+end

--- a/spec/evilution/config/env_loader_spec.rb
+++ b/spec/evilution/config/env_loader_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config"
+
+RSpec.describe Evilution::Config::EnvLoader do
+  describe ".load" do
+    before { ENV.delete("EV_DISABLE_EXAMPLE_TARGETING") }
+
+    it "returns {} when EV_DISABLE_EXAMPLE_TARGETING is unset" do
+      expect(described_class.load).to eq({})
+    end
+
+    it "returns {} when EV_DISABLE_EXAMPLE_TARGETING is empty" do
+      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = ""
+      expect(described_class.load).to eq({})
+    end
+
+    it "returns {} when EV_DISABLE_EXAMPLE_TARGETING is '0'" do
+      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = "0"
+      expect(described_class.load).to eq({})
+    end
+
+    it "disables example targeting when EV_DISABLE_EXAMPLE_TARGETING is '1'" do
+      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = "1"
+      expect(described_class.load).to eq(example_targeting: false)
+    end
+
+    it "disables example targeting for any non-zero, non-empty value" do
+      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = "yes"
+      expect(described_class.load).to eq(example_targeting: false)
+    end
+  end
+end

--- a/spec/evilution/config/file_loader_spec.rb
+++ b/spec/evilution/config/file_loader_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "evilution/config"
+
+RSpec.describe Evilution::Config::FileLoader do
+  around do |example|
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) { example.run }
+    end
+  end
+
+  describe ".load" do
+    it "returns {} when no config file exists" do
+      expect(described_class.load).to eq({})
+    end
+
+    it "reads .evilution.yml when present" do
+      File.write(".evilution.yml", "timeout: 42\n")
+      expect(described_class.load).to eq(timeout: 42)
+    end
+
+    it "reads config/evilution.yml when .evilution.yml is absent" do
+      Dir.mkdir("config")
+      File.write("config/evilution.yml", "jobs: 4\n")
+      expect(described_class.load).to eq(jobs: 4)
+    end
+
+    it "prefers .evilution.yml over config/evilution.yml" do
+      Dir.mkdir("config")
+      File.write(".evilution.yml", "timeout: 42\n")
+      File.write("config/evilution.yml", "timeout: 99\n")
+      expect(described_class.load).to eq(timeout: 42)
+    end
+
+    it "returns {} when YAML is not a Hash" do
+      File.write(".evilution.yml", "- one\n- two\n")
+      expect(described_class.load).to eq({})
+    end
+
+    it "wraps Psych::SyntaxError in Evilution::ConfigError" do
+      File.write(".evilution.yml", "timeout: [unclosed\n")
+      expect { described_class.load }.to raise_error(
+        Evilution::ConfigError,
+        /failed to parse config file \.evilution\.yml/
+      )
+    end
+
+    it "wraps Psych::DisallowedClass in Evilution::ConfigError" do
+      File.write(".evilution.yml", "timeout: !ruby/object:Object {}\n")
+      expect { described_class.load }.to raise_error(
+        Evilution::ConfigError,
+        /failed to parse config file \.evilution\.yml/
+      )
+    end
+
+    it "wraps SystemCallError in Evilution::ConfigError" do
+      File.write(".evilution.yml", "timeout: 1\n")
+      allow(YAML).to receive(:safe_load_file).and_raise(Errno::EACCES, "denied")
+      expect { described_class.load }.to raise_error(
+        Evilution::ConfigError,
+        /cannot read config file \.evilution\.yml/
+      )
+    end
+  end
+end

--- a/spec/evilution/config/sources_spec.rb
+++ b/spec/evilution/config/sources_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config"
+
+RSpec.describe Evilution::Config::Sources do
+  describe ".merge" do
+    before { ENV.delete("EV_DISABLE_EXAMPLE_TARGETING") }
+
+    it "returns DEFAULTS when no file, no env, no explicit" do
+      allow(Evilution::Config::FileLoader).to receive(:load).and_return({})
+      expect(described_class.merge(explicit: {}, skip_file: false))
+        .to include(timeout: 30, jobs: 1, integration: :rspec)
+    end
+
+    it "skips file when skip_file: true" do
+      expect(Evilution::Config::FileLoader).not_to receive(:load)
+      described_class.merge(explicit: {}, skip_file: true)
+    end
+
+    it "applies precedence: DEFAULTS < file < env < explicit" do
+      allow(Evilution::Config::FileLoader).to receive(:load)
+        .and_return(timeout: 60, jobs: 4, example_targeting: true)
+      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = "1"
+
+      merged = described_class.merge(explicit: { jobs: 8 }, skip_file: false)
+
+      expect(merged[:timeout]).to eq(60)
+      expect(merged[:example_targeting]).to eq(false)
+      expect(merged[:jobs]).to eq(8)
+    end
+  end
+end

--- a/spec/evilution/config/validators/base_spec.rb
+++ b/spec/evilution/config/validators/base_spec.rb
@@ -40,6 +40,21 @@ RSpec.describe Evilution::Config::Validators::Base do
       expect { subclass.call_coerce_symbol(:z) }
         .to raise_error(Evilution::ConfigError, "test must be a or b, got :z")
     end
+
+    it "raises ConfigError on Integer (not NoMethodError)" do
+      expect { subclass.call_coerce_symbol(1) }
+        .to raise_error(Evilution::ConfigError, "test must be a or b, got 1")
+    end
+
+    it "raises ConfigError on Boolean" do
+      expect { subclass.call_coerce_symbol(true) }
+        .to raise_error(Evilution::ConfigError, "test must be a or b, got true")
+    end
+
+    it "raises ConfigError on Array" do
+      expect { subclass.call_coerce_symbol([:a]) }
+        .to raise_error(Evilution::ConfigError, "test must be a or b, got [:a]")
+    end
   end
 
   describe "coerce_positive_int!" do

--- a/spec/evilution/config/validators/base_spec.rb
+++ b/spec/evilution/config/validators/base_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/base"
+
+RSpec.describe Evilution::Config::Validators::Base do
+  let(:subclass) do
+    Class.new(described_class) do
+      def self.call_coerce_symbol(value)
+        coerce_symbol!(value, allowed: %i[a b], name: "test")
+      end
+
+      def self.call_coerce_positive_int(value)
+        coerce_positive_int!(value, name: "test")
+      end
+    end
+  end
+
+  describe ".call" do
+    it "raises NotImplementedError" do
+      expect { described_class.call(1) }.to raise_error(NotImplementedError)
+    end
+  end
+
+  describe "coerce_symbol!" do
+    it "coerces string to allowed symbol" do
+      expect(subclass.call_coerce_symbol("a")).to eq(:a)
+    end
+
+    it "returns allowed symbol unchanged" do
+      expect(subclass.call_coerce_symbol(:b)).to eq(:b)
+    end
+
+    it "raises on nil with allowed list in message" do
+      expect { subclass.call_coerce_symbol(nil) }
+        .to raise_error(Evilution::ConfigError, "test must be a or b, got nil")
+    end
+
+    it "raises on disallowed value with symbol inspect" do
+      expect { subclass.call_coerce_symbol(:z) }
+        .to raise_error(Evilution::ConfigError, "test must be a or b, got :z")
+    end
+  end
+
+  describe "coerce_positive_int!" do
+    it "returns integer on positive int" do
+      expect(subclass.call_coerce_positive_int(3)).to eq(3)
+    end
+
+    it "coerces string integer" do
+      expect(subclass.call_coerce_positive_int("4")).to eq(4)
+    end
+
+    it "raises on Float" do
+      expect { subclass.call_coerce_positive_int(1.5) }
+        .to raise_error(Evilution::ConfigError, "test must be a positive integer, got 1.5")
+    end
+
+    it "raises on zero" do
+      expect { subclass.call_coerce_positive_int(0) }
+        .to raise_error(Evilution::ConfigError, "test must be a positive integer, got 0")
+    end
+
+    it "raises on non-numeric string" do
+      expect { subclass.call_coerce_positive_int("abc") }
+        .to raise_error(Evilution::ConfigError, 'test must be a positive integer, got "abc"')
+    end
+
+    it "raises on nil" do
+      expect { subclass.call_coerce_positive_int(nil) }
+        .to raise_error(Evilution::ConfigError, "test must be a positive integer, got nil")
+    end
+  end
+end

--- a/spec/evilution/config/validators/example_targeting_cache_spec.rb
+++ b/spec/evilution/config/validators/example_targeting_cache_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/example_targeting_cache"
+
+RSpec.describe Evilution::Config::Validators::ExampleTargetingCache do
+  describe ".call" do
+    it "merges supplied values over DEFAULTS" do
+      expect(described_class.call(max_files: 100))
+        .to eq(max_files: 100, max_blocks: 10_000)
+    end
+
+    it "accepts symbol keys" do
+      expect(described_class.call(max_blocks: 42)[:max_blocks]).to eq(42)
+    end
+
+    it "accepts string keys" do
+      expect(described_class.call("max_blocks" => 42)[:max_blocks]).to eq(42)
+    end
+
+    it "raises when value is not a Hash" do
+      expect { described_class.call(nil) }
+        .to raise_error(Evilution::ConfigError,
+                        "example_targeting_cache must be a Hash, got NilClass")
+    end
+
+    it "raises when key is not String or Symbol" do
+      expect { described_class.call(1 => 10) }
+        .to raise_error(Evilution::ConfigError,
+                        "example_targeting_cache keys must be Strings or Symbols, got 1")
+    end
+
+    it "raises on non-positive max_files" do
+      expect { described_class.call(max_files: 0) }
+        .to raise_error(Evilution::ConfigError,
+                        "example_targeting_cache.max_files must be a positive integer, got 0")
+    end
+
+    it "raises on non-integer max_blocks" do
+      expect { described_class.call(max_blocks: "lots") }
+        .to raise_error(Evilution::ConfigError,
+                        'example_targeting_cache.max_blocks must be a positive integer, got "lots"')
+    end
+  end
+end

--- a/spec/evilution/config/validators/example_targeting_fallback_spec.rb
+++ b/spec/evilution/config/validators/example_targeting_fallback_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/example_targeting_fallback"
+
+RSpec.describe Evilution::Config::Validators::ExampleTargetingFallback do
+  describe ".call" do
+    it "returns :full_file for :full_file" do
+      expect(described_class.call(:full_file)).to eq(:full_file)
+    end
+
+    it "returns :unresolved for :unresolved" do
+      expect(described_class.call(:unresolved)).to eq(:unresolved)
+    end
+
+    it "coerces string to symbol" do
+      expect(described_class.call("full_file")).to eq(:full_file)
+    end
+
+    it "raises on nil" do
+      expect { described_class.call(nil) }
+        .to raise_error(Evilution::ConfigError,
+                        "example_targeting_fallback must be full_file or unresolved, got nil")
+    end
+
+    it "raises on unknown symbol" do
+      expect { described_class.call(:foo) }
+        .to raise_error(Evilution::ConfigError,
+                        "example_targeting_fallback must be full_file or unresolved, got :foo")
+    end
+
+    it "raises on non-string/symbol" do
+      expect { described_class.call(123) }
+        .to raise_error(Evilution::ConfigError,
+                        "example_targeting_fallback must be full_file or unresolved, got 123")
+    end
+  end
+end

--- a/spec/evilution/config/validators/fail_fast_spec.rb
+++ b/spec/evilution/config/validators/fail_fast_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/fail_fast"
+
+RSpec.describe Evilution::Config::Validators::FailFast do
+  describe ".call" do
+    it "returns nil for nil" do
+      expect(described_class.call(nil)).to be_nil
+    end
+
+    it "returns integer for positive int" do
+      expect(described_class.call(3)).to eq(3)
+    end
+
+    it "coerces string integer" do
+      expect(described_class.call("5")).to eq(5)
+    end
+
+    it "raises on zero" do
+      expect { described_class.call(0) }
+        .to raise_error(Evilution::ConfigError, "fail_fast must be a positive integer, got 0")
+    end
+
+    it "raises on negative" do
+      expect { described_class.call(-2) }
+        .to raise_error(Evilution::ConfigError, "fail_fast must be a positive integer, got -2")
+    end
+
+    it "raises on non-numeric string" do
+      expect { described_class.call("abc") }
+        .to raise_error(Evilution::ConfigError, 'fail_fast must be a positive integer, got "abc"')
+    end
+  end
+end

--- a/spec/evilution/config/validators/hooks_spec.rb
+++ b/spec/evilution/config/validators/hooks_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/hooks"
+
+RSpec.describe Evilution::Config::Validators::Hooks do
+  describe ".call" do
+    it "returns {} for nil" do
+      expect(described_class.call(nil)).to eq({})
+    end
+
+    it "returns the Hash unchanged" do
+      hooks = { worker_process_start: "path/to/hook.rb" }
+      expect(described_class.call(hooks)).to eq(hooks)
+    end
+
+    it "raises on Array" do
+      expect { described_class.call(["a"]) }
+        .to raise_error(Evilution::ConfigError, "hooks must be a mapping of event names to file paths, got Array")
+    end
+
+    it "raises on String" do
+      expect { described_class.call("oops") }
+        .to raise_error(Evilution::ConfigError, "hooks must be a mapping of event names to file paths, got String")
+    end
+  end
+end

--- a/spec/evilution/config/validators/ignore_patterns_spec.rb
+++ b/spec/evilution/config/validators/ignore_patterns_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/ignore_patterns"
+
+RSpec.describe Evilution::Config::Validators::IgnorePatterns do
+  describe ".call" do
+    it "returns [] for nil" do
+      expect(described_class.call(nil)).to eq([])
+    end
+
+    it "returns the Array of strings" do
+      expect(described_class.call(["call{name=info}"])).to eq(["call{name=info}"])
+    end
+
+    it "wraps a single string in an array" do
+      expect(described_class.call("call{name=info}")).to eq(["call{name=info}"])
+    end
+
+    it "raises on non-string element" do
+      expect { described_class.call([123]) }
+        .to raise_error(Evilution::ConfigError,
+                        "ignore_patterns must be an array of strings, got Integer (123)")
+    end
+  end
+end

--- a/spec/evilution/config/validators/integration_spec.rb
+++ b/spec/evilution/config/validators/integration_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/integration"
+
+RSpec.describe Evilution::Config::Validators::Integration do
+  describe ".call" do
+    it "returns :rspec for :rspec" do
+      expect(described_class.call(:rspec)).to eq(:rspec)
+    end
+
+    it "returns :minitest for :minitest" do
+      expect(described_class.call(:minitest)).to eq(:minitest)
+    end
+
+    it "coerces string 'rspec' to :rspec" do
+      expect(described_class.call("rspec")).to eq(:rspec)
+    end
+
+    it "raises on nil" do
+      expect { described_class.call(nil) }
+        .to raise_error(Evilution::ConfigError, "integration must be rspec or minitest, got nil")
+    end
+
+    it "raises on unknown value" do
+      expect { described_class.call(:foo) }
+        .to raise_error(Evilution::ConfigError, "integration must be rspec or minitest, got :foo")
+    end
+  end
+end

--- a/spec/evilution/config/validators/integration_spec.rb
+++ b/spec/evilution/config/validators/integration_spec.rb
@@ -26,5 +26,10 @@ RSpec.describe Evilution::Config::Validators::Integration do
       expect { described_class.call(:foo) }
         .to raise_error(Evilution::ConfigError, "integration must be rspec or minitest, got :foo")
     end
+
+    it "raises ConfigError on Integer (not NoMethodError)" do
+      expect { described_class.call(1) }
+        .to raise_error(Evilution::ConfigError, "integration must be rspec or minitest, got 1")
+    end
   end
 end

--- a/spec/evilution/config/validators/isolation_spec.rb
+++ b/spec/evilution/config/validators/isolation_spec.rb
@@ -24,5 +24,15 @@ RSpec.describe Evilution::Config::Validators::Isolation do
       expect { described_class.call(:foo) }
         .to raise_error(Evilution::ConfigError, "isolation must be auto, fork, or in_process, got :foo")
     end
+
+    it "raises ConfigError on Integer (not NoMethodError)" do
+      expect { described_class.call(1) }
+        .to raise_error(Evilution::ConfigError, "isolation must be auto, fork, or in_process, got 1")
+    end
+
+    it "raises ConfigError on Boolean" do
+      expect { described_class.call(true) }
+        .to raise_error(Evilution::ConfigError, "isolation must be auto, fork, or in_process, got true")
+    end
   end
 end

--- a/spec/evilution/config/validators/isolation_spec.rb
+++ b/spec/evilution/config/validators/isolation_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/isolation"
+
+RSpec.describe Evilution::Config::Validators::Isolation do
+  describe ".call" do
+    %i[auto fork in_process].each do |value|
+      it "returns #{value.inspect} for #{value.inspect}" do
+        expect(described_class.call(value)).to eq(value)
+      end
+    end
+
+    it "coerces string 'auto' to :auto" do
+      expect(described_class.call("auto")).to eq(:auto)
+    end
+
+    it "raises on nil" do
+      expect { described_class.call(nil) }
+        .to raise_error(Evilution::ConfigError, "isolation must be auto, fork, or in_process, got nil")
+    end
+
+    it "raises on unknown value" do
+      expect { described_class.call(:foo) }
+        .to raise_error(Evilution::ConfigError, "isolation must be auto, fork, or in_process, got :foo")
+    end
+  end
+end

--- a/spec/evilution/config/validators/jobs_spec.rb
+++ b/spec/evilution/config/validators/jobs_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/jobs"
+
+RSpec.describe Evilution::Config::Validators::Jobs do
+  describe ".call" do
+    it "returns the integer when >= 1" do
+      expect(described_class.call(4)).to eq(4)
+    end
+
+    it "coerces string integer" do
+      expect(described_class.call("2")).to eq(2)
+    end
+
+    it "raises on Float" do
+      expect { described_class.call(2.5) }
+        .to raise_error(Evilution::ConfigError, "jobs must be a positive integer, got 2.5")
+    end
+
+    it "raises on zero" do
+      expect { described_class.call(0) }
+        .to raise_error(Evilution::ConfigError, "jobs must be a positive integer, got 0")
+    end
+
+    it "raises on negative" do
+      expect { described_class.call(-1) }
+        .to raise_error(Evilution::ConfigError, "jobs must be a positive integer, got -1")
+    end
+
+    it "raises on non-numeric string" do
+      expect { described_class.call("abc") }
+        .to raise_error(Evilution::ConfigError, 'jobs must be a positive integer, got "abc"')
+    end
+
+    it "raises on nil" do
+      expect { described_class.call(nil) }
+        .to raise_error(Evilution::ConfigError, "jobs must be a positive integer, got nil")
+    end
+  end
+end

--- a/spec/evilution/config/validators/preload_spec.rb
+++ b/spec/evilution/config/validators/preload_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/preload"
+
+RSpec.describe Evilution::Config::Validators::Preload do
+  describe ".call" do
+    it "returns nil for nil" do
+      expect(described_class.call(nil)).to be_nil
+    end
+
+    it "returns false for false" do
+      expect(described_class.call(false)).to eq(false)
+    end
+
+    it "returns the String path" do
+      expect(described_class.call("spec/helper.rb")).to eq("spec/helper.rb")
+    end
+
+    it "raises on Integer" do
+      expect { described_class.call(1) }
+        .to raise_error(Evilution::ConfigError, "preload must be nil, false, or a String path, got 1")
+    end
+
+    it "raises on true" do
+      expect { described_class.call(true) }
+        .to raise_error(Evilution::ConfigError, "preload must be nil, false, or a String path, got true")
+    end
+  end
+end

--- a/spec/evilution/config/validators/spec_mappings_spec.rb
+++ b/spec/evilution/config/validators/spec_mappings_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "fileutils"
+require "evilution/config/validators/spec_mappings"
+
+RSpec.describe Evilution::Config::Validators::SpecMappings do
+  describe ".call" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) { example.run }
+      end
+    end
+
+    it "returns {} for nil" do
+      expect(described_class.call(nil)).to eq({})
+    end
+
+    it "raises when value is not a Hash" do
+      expect { described_class.call("oops") }
+        .to raise_error(Evilution::ConfigError, "spec_mappings must be a Hash, got String")
+    end
+
+    it "normalizes String values to single-element arrays" do
+      FileUtils.mkdir_p("spec")
+      File.write("spec/foo_spec.rb", "")
+      result = described_class.call("lib/foo.rb" => "spec/foo_spec.rb")
+      expect(result).to eq("lib/foo.rb" => ["spec/foo_spec.rb"])
+    end
+
+    it "strips absolute path prefix matching Dir.pwd" do
+      FileUtils.mkdir_p("spec")
+      File.write("spec/foo_spec.rb", "")
+      abs = File.join(Dir.pwd, "lib/foo.rb")
+      result = described_class.call(abs => ["spec/foo_spec.rb"])
+      expect(result.keys).to eq(["lib/foo.rb"])
+    end
+
+    it "strips ./ prefix" do
+      FileUtils.mkdir_p("spec")
+      File.write("spec/foo_spec.rb", "")
+      result = described_class.call("./lib/foo.rb" => ["spec/foo_spec.rb"])
+      expect(result.keys).to eq(["lib/foo.rb"])
+    end
+
+    it "raises when array entry is not a String" do
+      expect { described_class.call("lib/foo.rb" => [123]) }
+        .to raise_error(Evilution::ConfigError,
+                        %r{spec_mappings\["lib/foo\.rb"\] entries must be string paths, got Integer})
+    end
+
+    it "raises when value is neither String nor Array" do
+      expect { described_class.call("lib/foo.rb" => 123) }
+        .to raise_error(Evilution::ConfigError,
+                        %r{spec_mappings\["lib/foo\.rb"\] must be a string or array of strings, got Integer})
+    end
+
+    it "warns on missing spec paths" do
+      expect do
+        described_class.call("lib/foo.rb" => ["spec/missing_spec.rb"])
+      end.to output(%r{\[evilution\] spec_mappings\["lib/foo\.rb"\]: spec/missing_spec\.rb not found, skipping}).to_stderr
+    end
+  end
+end

--- a/spec/evilution/config/validators/spec_pattern_spec.rb
+++ b/spec/evilution/config/validators/spec_pattern_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/config/validators/spec_pattern"
+
+RSpec.describe Evilution::Config::Validators::SpecPattern do
+  describe ".call" do
+    it "returns nil for nil" do
+      expect(described_class.call(nil)).to be_nil
+    end
+
+    it "returns the String glob" do
+      expect(described_class.call("spec/**/*_spec.rb")).to eq("spec/**/*_spec.rb")
+    end
+
+    it "raises on Array" do
+      expect { described_class.call(["a"]) }
+        .to raise_error(Evilution::ConfigError, "spec_pattern must be nil or a String glob, got Array")
+    end
+
+    it "raises on Integer" do
+      expect { described_class.call(1) }
+        .to raise_error(Evilution::ConfigError, "spec_pattern must be nil or a String glob, got Integer")
+    end
+  end
+end

--- a/spec/evilution/config_spec.rb
+++ b/spec/evilution/config_spec.rb
@@ -5,6 +5,26 @@ require "tmpdir"
 require "fileutils"
 
 RSpec.describe Evilution::Config do
+  describe "constants" do
+    it "exposes CONFIG_FILES with the expected search order" do
+      expect(described_class::CONFIG_FILES).to eq(%w[.evilution.yml config/evilution.yml])
+    end
+
+    it "freezes CONFIG_FILES" do
+      expect(described_class::CONFIG_FILES).to be_frozen
+    end
+
+    it "exposes DEFAULTS with representative defaults" do
+      expect(described_class::DEFAULTS).to include(
+        timeout: 30, format: :text, integration: :rspec, jobs: 1, isolation: :auto
+      )
+    end
+
+    it "freezes DEFAULTS" do
+      expect(described_class::DEFAULTS).to be_frozen
+    end
+  end
+
   describe "defaults" do
     subject(:config) { described_class.new(skip_config_file: true) }
 
@@ -24,8 +44,9 @@ RSpec.describe Evilution::Config do
       expect(config.min_score).to eq(0.0)
     end
 
-    it "sets integration to :rspec" do
+    it "sets integration to :rspec (Symbol)" do
       expect(config.integration).to eq(:rspec)
+      expect(config.integration).to be_a(Symbol)
     end
 
     it "disables verbose by default" do
@@ -50,6 +71,23 @@ RSpec.describe Evilution::Config do
 
     it "disables suggest_tests by default" do
       expect(config.suggest_tests).to be false
+    end
+
+    it "sets ignore_patterns to an empty Array" do
+      expect(config.ignore_patterns).to eq([])
+      expect(config.ignore_patterns).to be_a(Array)
+    end
+
+    it "defaults hooks to empty hash" do
+      expect(config.hooks).to eq({})
+    end
+
+    it "defaults jobs to 1" do
+      expect(config.jobs).to eq(1)
+    end
+
+    it "defaults isolation to :auto" do
+      expect(config.isolation).to eq(:auto)
     end
   end
 
@@ -102,27 +140,11 @@ RSpec.describe Evilution::Config do
       expect(config.spec_files).to eq(["spec/foo_spec.rb"])
     end
 
-    it "defaults hooks to empty hash" do
-      config = described_class.new(skip_config_file: true)
-
-      expect(config.hooks).to eq({})
-    end
-
     it "accepts hooks configuration" do
       hooks_config = { worker_process_start: "config/hooks/worker.rb" }
       config = described_class.new(hooks: hooks_config, skip_config_file: true)
 
       expect(config.hooks).to eq(hooks_config)
-    end
-
-    it "rejects non-hash hooks value" do
-      expect { described_class.new(hooks: "not_a_hash", skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /hooks must be a mapping/)
-    end
-
-    it "rejects array hooks value" do
-      expect { described_class.new(hooks: ["file.rb"], skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /hooks must be a mapping/)
     end
 
     it "accepts fail_fast" do
@@ -138,7 +160,7 @@ RSpec.describe Evilution::Config do
     end
   end
 
-  describe "config file loading" do
+  describe "config file loading (orchestration)" do
     around do |example|
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) { example.run }
@@ -154,25 +176,6 @@ RSpec.describe Evilution::Config do
       expect(config.format).to eq(:json)
     end
 
-    it "loads settings from config/evilution.yml" do
-      Dir.mkdir("config")
-      File.write("config/evilution.yml", "timeout: 20\n")
-
-      config = described_class.new
-
-      expect(config.timeout).to eq(20)
-    end
-
-    it "prefers .evilution.yml over config/evilution.yml" do
-      File.write(".evilution.yml", "timeout: 30\n")
-      Dir.mkdir("config")
-      File.write("config/evilution.yml", "timeout: 20\n")
-
-      config = described_class.new
-
-      expect(config.timeout).to eq(30)
-    end
-
     it "CLI options override file settings" do
       File.write(".evilution.yml", "timeout: 30\n")
 
@@ -181,227 +184,40 @@ RSpec.describe Evilution::Config do
       expect(config.timeout).to eq(5)
     end
 
-    it "handles empty config file gracefully" do
-      File.write(".evilution.yml", "")
+    it "skip_config_file: true bypasses file reading" do
+      File.write(".evilution.yml", "timeout: 999\n")
 
-      config = described_class.new
-
-      expect(config.timeout).to eq(30) # default
-    end
-
-    it "loads ignore_patterns from YAML" do
-      yaml = <<~YAML
-        ignore_patterns:
-          - "call{name=info, receiver=call{name=logger}}"
-          - "call{name=debug|warn}"
-      YAML
-      File.write(".evilution.yml", yaml)
-
-      config = described_class.new
-
-      expect(config.ignore_patterns).to eq([
-                                             "call{name=info, receiver=call{name=logger}}",
-                                             "call{name=debug|warn}"
-                                           ])
-    end
-
-    it "defaults ignore_patterns to empty when not in YAML" do
-      File.write(".evilution.yml", "timeout: 10\n")
-
-      config = described_class.new
-
-      expect(config.ignore_patterns).to eq([])
-    end
-
-    it "CLI options override ignore_patterns from file" do
-      File.write(".evilution.yml", "ignore_patterns:\n  - \"call{name=log}\"\n")
-
-      config = described_class.new(ignore_patterns: ["call{name=debug}"])
-
-      expect(config.ignore_patterns).to eq(["call{name=debug}"])
-    end
-
-    it "loads skip_heredoc_literals from YAML" do
-      File.write(".evilution.yml", "skip_heredoc_literals: true\n")
-
-      config = described_class.new
-
-      expect(config.skip_heredoc_literals?).to be true
-    end
-
-    it "defaults skip_heredoc_literals to false when not in YAML" do
-      File.write(".evilution.yml", "timeout: 10\n")
-
-      config = described_class.new
-
-      expect(config.skip_heredoc_literals?).to be false
-    end
-
-    it "CLI options override skip_heredoc_literals from file" do
-      File.write(".evilution.yml", "skip_heredoc_literals: true\n")
-
-      config = described_class.new(skip_heredoc_literals: false)
-
-      expect(config.skip_heredoc_literals?).to be false
-    end
-
-    it "loads related_specs_heuristic from YAML" do
-      File.write(".evilution.yml", "related_specs_heuristic: true\n")
-
-      config = described_class.new
-
-      expect(config.related_specs_heuristic?).to be true
-    end
-
-    it "defaults related_specs_heuristic to false when not in YAML" do
-      File.write(".evilution.yml", "timeout: 10\n")
-
-      config = described_class.new
-
-      expect(config.related_specs_heuristic?).to be false
-    end
-
-    it "CLI options override related_specs_heuristic from file" do
-      File.write(".evilution.yml", "related_specs_heuristic: true\n")
-
-      config = described_class.new(related_specs_heuristic: false)
-
-      expect(config.related_specs_heuristic?).to be false
-    end
-
-    it "defaults fallback_to_full_suite to false" do
       config = described_class.new(skip_config_file: true)
 
-      expect(config.fallback_to_full_suite?).to be false
+      expect(config.timeout).to eq(30)
     end
 
-    it "loads fallback_to_full_suite from YAML" do
-      File.write(".evilution.yml", "fallback_to_full_suite: true\n")
+    it "end-to-end merge exposes both file and explicit values" do
+      File.write(".evilution.yml", "timeout: 60\nformat: json\n")
 
-      config = described_class.new
+      config = described_class.new(jobs: 4)
 
-      expect(config.fallback_to_full_suite?).to be true
+      expect(config.timeout).to eq(60)
+      expect(config.format).to eq(:json)
+      expect(config.jobs).to eq(4)
+    end
+  end
+
+  describe ".file_options" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) { example.run }
+      end
     end
 
-    it "CLI options override fallback_to_full_suite from file" do
-      File.write(".evilution.yml", "fallback_to_full_suite: true\n")
+    it "delegates to FileLoader and returns parsed symbol-keyed options" do
+      File.write(".evilution.yml", "timeout: 42\n")
 
-      config = described_class.new(fallback_to_full_suite: false)
-
-      expect(config.fallback_to_full_suite?).to be false
+      expect(described_class.file_options).to eq(timeout: 42)
     end
 
-    it "defaults spec_mappings to empty hash" do
-      config = described_class.new(skip_config_file: true)
-
-      expect(config.spec_mappings).to eq({})
-    end
-
-    it "defaults spec_pattern to nil" do
-      config = described_class.new(skip_config_file: true)
-
-      expect(config.spec_pattern).to be_nil
-    end
-
-    it "loads spec_mappings from YAML and normalizes string values to arrays" do
-      File.write(".evilution.yml", <<~YAML)
-        spec_mappings:
-          app/controllers/games_controller.rb:
-            - spec/requests/games_overlay_spec.rb
-            - spec/requests/games_spec.rb
-          lib/shared/util.rb: spec/lib/shared/util_spec.rb
-      YAML
-
-      config = described_class.new
-
-      expect(config.spec_mappings).to eq(
-        "app/controllers/games_controller.rb" => [
-          "spec/requests/games_overlay_spec.rb",
-          "spec/requests/games_spec.rb"
-        ],
-        "lib/shared/util.rb" => ["spec/lib/shared/util_spec.rb"]
-      )
-    end
-
-    it "loads spec_pattern from YAML" do
-      File.write(".evilution.yml", "spec_pattern: \"spec/requests/**/*_spec.rb\"\n")
-
-      config = described_class.new
-
-      expect(config.spec_pattern).to eq("spec/requests/**/*_spec.rb")
-    end
-
-    it "CLI options override spec_pattern from file" do
-      File.write(".evilution.yml", "spec_pattern: \"spec/requests/**/*_spec.rb\"\n")
-
-      config = described_class.new(spec_pattern: "spec/helpers/**/*_spec.rb")
-
-      expect(config.spec_pattern).to eq("spec/helpers/**/*_spec.rb")
-    end
-
-    it "raises ConfigError when spec_mappings is not a hash" do
-      File.write(".evilution.yml", "spec_mappings: nope\n")
-
-      expect { described_class.new }.to raise_error(Evilution::ConfigError, /spec_mappings.*Hash/)
-    end
-
-    it "raises ConfigError when spec_mappings value is not a string or array" do
-      expect do
-        described_class.new(skip_config_file: true, spec_mappings: { "lib/foo.rb" => 42 })
-      end.to raise_error(Evilution::ConfigError, /spec_mappings.*string or array/)
-    end
-
-    it "raises ConfigError when spec_mappings array contains non-strings" do
-      expect do
-        described_class.new(skip_config_file: true, spec_mappings: { "lib/foo.rb" => [42] })
-      end.to raise_error(Evilution::ConfigError, /spec_mappings.*string/)
-    end
-
-    it "raises ConfigError when spec_pattern is not a string" do
-      expect do
-        described_class.new(skip_config_file: true, spec_pattern: 42)
-      end.to raise_error(Evilution::ConfigError, /spec_pattern.*String/)
-    end
-
-    it "warns when spec_mappings entry references a missing file" do
-      expect do
-        described_class.new(
-          skip_config_file: true,
-          spec_mappings: { "lib/foo.rb" => "spec/missing_spec.rb" }
-        )
-      end.to output(%r{spec_mappings.*spec/missing_spec\.rb.*not found}).to_stderr
-    end
-
-    it "does not warn when all spec_mappings entries exist" do
-      File.write("existing_spec.rb", "")
-
-      expect do
-        described_class.new(
-          skip_config_file: true,
-          spec_mappings: { "lib/foo.rb" => "existing_spec.rb" }
-        )
-      end.not_to output.to_stderr
-    end
-
-    it "normalizes leading ./ in spec_mappings keys" do
-      File.write("existing_spec.rb", "")
-      config = described_class.new(
-        skip_config_file: true,
-        spec_mappings: { "./lib/foo.rb" => "existing_spec.rb" }
-      )
-
-      expect(config.spec_mappings).to have_key("lib/foo.rb")
-      expect(config.spec_mappings).not_to have_key("./lib/foo.rb")
-    end
-
-    it "normalizes absolute (pwd-prefixed) spec_mappings keys" do
-      File.write("existing_spec.rb", "")
-      config = described_class.new(
-        skip_config_file: true,
-        spec_mappings: { "#{Dir.pwd}/lib/foo.rb" => "existing_spec.rb" }
-      )
-
-      expect(config.spec_mappings).to have_key("lib/foo.rb")
+    it "returns {} when no config file exists" do
+      expect(described_class.file_options).to eq({})
     end
   end
 
@@ -484,7 +300,14 @@ RSpec.describe Evilution::Config do
   end
 
   describe ".default_template" do
-    it "returns a YAML string with commented-out options" do
+    it "returns a non-empty YAML string containing the Evilution configuration header" do
+      template = described_class.default_template
+
+      expect(template).not_to be_empty
+      expect(template).to include("Evilution configuration")
+    end
+
+    it "includes commented-out options" do
       template = described_class.default_template
 
       expect(template).to include("# timeout:")
@@ -492,298 +315,177 @@ RSpec.describe Evilution::Config do
     end
   end
 
-  describe "#json?" do
-    it "returns true when format is json" do
-      config = described_class.new(format: :json, skip_config_file: true)
+  describe "predicate methods" do
+    describe "#json?" do
+      it "returns true when format is json" do
+        config = described_class.new(format: :json, skip_config_file: true)
 
-      expect(config.json?).to be true
+        expect(config.json?).to be true
+      end
+
+      it "returns false when format is text" do
+        config = described_class.new(format: :text, skip_config_file: true)
+
+        expect(config.json?).to be false
+      end
     end
 
-    it "returns false when format is text" do
-      config = described_class.new(format: :text, skip_config_file: true)
+    describe "#text?" do
+      it "returns true when format is text" do
+        config = described_class.new(format: :text, skip_config_file: true)
 
-      expect(config.json?).to be false
-    end
-  end
+        expect(config.text?).to be true
+      end
 
-  describe "#text?" do
-    it "returns true when format is text" do
-      config = described_class.new(format: :text, skip_config_file: true)
+      it "returns false when format is json" do
+        config = described_class.new(format: :json, skip_config_file: true)
 
-      expect(config.text?).to be true
-    end
-
-    it "returns false when format is json" do
-      config = described_class.new(format: :json, skip_config_file: true)
-
-      expect(config.text?).to be false
-    end
-  end
-
-  describe "#html?" do
-    it "returns true when format is html" do
-      config = described_class.new(format: :html, skip_config_file: true)
-
-      expect(config.html?).to be true
+        expect(config.text?).to be false
+      end
     end
 
-    it "returns false when format is text" do
-      config = described_class.new(format: :text, skip_config_file: true)
+    describe "#html?" do
+      it "returns true when format is html" do
+        config = described_class.new(format: :html, skip_config_file: true)
 
-      expect(config.html?).to be false
-    end
-  end
+        expect(config.html?).to be true
+      end
 
-  describe "#line_ranges?" do
-    it "returns true when line_ranges is non-empty" do
-      config = described_class.new(line_ranges: { "lib/foo.rb" => 10..20 }, skip_config_file: true)
+      it "returns false when format is text" do
+        config = described_class.new(format: :text, skip_config_file: true)
 
-      expect(config.line_ranges?).to be true
-    end
-
-    it "returns false when line_ranges is empty" do
-      config = described_class.new(skip_config_file: true)
-
-      expect(config.line_ranges?).to be false
-    end
-  end
-
-  describe "#target?" do
-    it "returns true when target is set" do
-      config = described_class.new(target: "Foo#bar", skip_config_file: true)
-
-      expect(config.target?).to be true
+        expect(config.html?).to be false
+      end
     end
 
-    it "returns false when target is nil" do
-      config = described_class.new(skip_config_file: true)
+    describe "#line_ranges?" do
+      it "returns true when line_ranges is non-empty" do
+        config = described_class.new(line_ranges: { "lib/foo.rb" => 10..20 }, skip_config_file: true)
 
-      expect(config.target?).to be false
-    end
-  end
+        expect(config.line_ranges?).to be true
+      end
 
-  describe "#fail_fast?" do
-    it "returns true when fail_fast is set" do
-      config = described_class.new(fail_fast: 1, skip_config_file: true)
+      it "returns false when line_ranges is empty" do
+        config = described_class.new(skip_config_file: true)
 
-      expect(config.fail_fast?).to be true
-    end
-
-    it "returns false when fail_fast is nil" do
-      config = described_class.new(skip_config_file: true)
-
-      expect(config.fail_fast?).to be false
-    end
-  end
-
-  describe "#suggest_tests?" do
-    it "returns true when suggest_tests is enabled" do
-      config = described_class.new(suggest_tests: true, skip_config_file: true)
-
-      expect(config.suggest_tests?).to be true
+        expect(config.line_ranges?).to be false
+      end
     end
 
-    it "returns false when suggest_tests is disabled" do
-      config = described_class.new(skip_config_file: true)
+    describe "#target?" do
+      it "returns true when target is set" do
+        config = described_class.new(target: "Foo#bar", skip_config_file: true)
 
-      expect(config.suggest_tests?).to be false
-    end
-  end
+        expect(config.target?).to be true
+      end
 
-  describe "#progress?" do
-    it "returns true by default" do
-      config = described_class.new(skip_config_file: true)
+      it "returns false when target is nil" do
+        config = described_class.new(skip_config_file: true)
 
-      expect(config.progress?).to be true
-    end
-
-    it "returns false when progress is disabled" do
-      config = described_class.new(progress: false, skip_config_file: true)
-
-      expect(config.progress?).to be false
-    end
-  end
-
-  describe "#show_disabled?" do
-    it "returns false by default" do
-      config = described_class.new(skip_config_file: true)
-
-      expect(config.show_disabled?).to be false
+        expect(config.target?).to be false
+      end
     end
 
-    it "returns true when show_disabled is enabled" do
-      config = described_class.new(show_disabled: true, skip_config_file: true)
+    describe "#fail_fast?" do
+      it "returns true when fail_fast is set" do
+        config = described_class.new(fail_fast: 1, skip_config_file: true)
 
-      expect(config.show_disabled?).to be true
-    end
-  end
+        expect(config.fail_fast?).to be true
+      end
 
-  describe "#skip_heredoc_literals?" do
-    it "returns false by default" do
-      config = described_class.new(skip_config_file: true)
+      it "returns false when fail_fast is nil" do
+        config = described_class.new(skip_config_file: true)
 
-      expect(config.skip_heredoc_literals?).to be false
-    end
-
-    it "returns true when skip_heredoc_literals is enabled" do
-      config = described_class.new(skip_heredoc_literals: true, skip_config_file: true)
-
-      expect(config.skip_heredoc_literals?).to be true
-    end
-  end
-
-  describe "#related_specs_heuristic?" do
-    it "returns false by default" do
-      config = described_class.new(skip_config_file: true)
-
-      expect(config.related_specs_heuristic?).to be false
+        expect(config.fail_fast?).to be false
+      end
     end
 
-    it "returns true when related_specs_heuristic is enabled" do
-      config = described_class.new(related_specs_heuristic: true, skip_config_file: true)
+    describe "#suggest_tests?" do
+      it "returns true when suggest_tests is enabled" do
+        config = described_class.new(suggest_tests: true, skip_config_file: true)
 
-      expect(config.related_specs_heuristic?).to be true
-    end
-  end
+        expect(config.suggest_tests?).to be true
+      end
 
-  describe "fail_fast validation" do
-    it "rejects zero" do
-      expect { described_class.new(fail_fast: 0, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /positive integer/)
-    end
+      it "returns false when suggest_tests is disabled" do
+        config = described_class.new(skip_config_file: true)
 
-    it "rejects negative values" do
-      expect { described_class.new(fail_fast: -1, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /positive integer/)
+        expect(config.suggest_tests?).to be false
+      end
     end
 
-    it "rejects non-integer string values" do
-      expect { described_class.new(fail_fast: "abc", skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /positive integer/)
+    describe "#progress?" do
+      it "returns true by default" do
+        config = described_class.new(skip_config_file: true)
+
+        expect(config.progress?).to be true
+      end
+
+      it "returns false when progress is disabled" do
+        config = described_class.new(progress: false, skip_config_file: true)
+
+        expect(config.progress?).to be false
+      end
     end
 
-    it "rejects boolean values" do
-      expect { described_class.new(fail_fast: true, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /positive integer/)
+    describe "#show_disabled?" do
+      it "returns false by default" do
+        config = described_class.new(skip_config_file: true)
+
+        expect(config.show_disabled?).to be false
+      end
+
+      it "returns true when show_disabled is enabled" do
+        config = described_class.new(show_disabled: true, skip_config_file: true)
+
+        expect(config.show_disabled?).to be true
+      end
+    end
+
+    describe "#skip_heredoc_literals?" do
+      it "returns false by default" do
+        config = described_class.new(skip_config_file: true)
+
+        expect(config.skip_heredoc_literals?).to be false
+      end
+
+      it "returns true when skip_heredoc_literals is enabled" do
+        config = described_class.new(skip_heredoc_literals: true, skip_config_file: true)
+
+        expect(config.skip_heredoc_literals?).to be true
+      end
+    end
+
+    describe "#related_specs_heuristic?" do
+      it "returns false by default" do
+        config = described_class.new(skip_config_file: true)
+
+        expect(config.related_specs_heuristic?).to be false
+      end
+
+      it "returns true when related_specs_heuristic is enabled" do
+        config = described_class.new(related_specs_heuristic: true, skip_config_file: true)
+
+        expect(config.related_specs_heuristic?).to be true
+      end
+    end
+
+    describe "#fallback_to_full_suite?" do
+      it "returns false by default" do
+        config = described_class.new(skip_config_file: true)
+
+        expect(config.fallback_to_full_suite?).to be false
+      end
+
+      it "returns true when enabled" do
+        config = described_class.new(fallback_to_full_suite: true, skip_config_file: true)
+
+        expect(config.fallback_to_full_suite?).to be true
+      end
     end
   end
 
-  describe "jobs validation" do
-    it "defaults to 1" do
-      config = described_class.new(skip_config_file: true)
-      expect(config.jobs).to eq(1)
-    end
-
-    it "accepts positive integers" do
-      config = described_class.new(jobs: 4, skip_config_file: true)
-      expect(config.jobs).to eq(4)
-    end
-
-    it "rejects zero" do
-      expect { described_class.new(jobs: 0, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /positive integer/)
-    end
-
-    it "rejects negative values" do
-      expect { described_class.new(jobs: -1, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /positive integer/)
-    end
-
-    it "rejects non-integer string values" do
-      expect { described_class.new(jobs: "abc", skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /positive integer/)
-    end
-
-    it "rejects float values" do
-      expect { described_class.new(jobs: 2.5, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /positive integer/)
-    end
-  end
-
-  describe "isolation validation" do
-    it "defaults to :auto" do
-      config = described_class.new(skip_config_file: true)
-      expect(config.isolation).to eq(:auto)
-    end
-
-    it "accepts :fork" do
-      config = described_class.new(isolation: :fork, skip_config_file: true)
-      expect(config.isolation).to eq(:fork)
-    end
-
-    it "accepts :in_process" do
-      config = described_class.new(isolation: :in_process, skip_config_file: true)
-      expect(config.isolation).to eq(:in_process)
-    end
-
-    it "accepts string values and converts to symbol" do
-      config = described_class.new(isolation: "fork", skip_config_file: true)
-      expect(config.isolation).to eq(:fork)
-    end
-
-    it "rejects invalid values" do
-      expect { described_class.new(isolation: :invalid, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /isolation must be/)
-    end
-
-    it "rejects nil values" do
-      expect { described_class.new(isolation: nil, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /isolation must be/)
-    end
-  end
-
-  describe "integration validation" do
-    it "defaults to :rspec" do
-      config = described_class.new(skip_config_file: true)
-      expect(config.integration).to eq(:rspec)
-    end
-
-    it "accepts :minitest" do
-      config = described_class.new(integration: :minitest, skip_config_file: true)
-      expect(config.integration).to eq(:minitest)
-    end
-
-    it "accepts string values and converts to symbol" do
-      config = described_class.new(integration: "minitest", skip_config_file: true)
-      expect(config.integration).to eq(:minitest)
-    end
-
-    it "rejects invalid values" do
-      expect { described_class.new(integration: :cucumber, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /integration must be/)
-    end
-
-    it "rejects nil values" do
-      expect { described_class.new(integration: nil, skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /integration must be/)
-    end
-  end
-
-  describe "ignore_patterns" do
-    it "defaults to empty array" do
-      config = described_class.new(skip_config_file: true)
-
-      expect(config.ignore_patterns).to eq([])
-    end
-
-    it "accepts an array of strings" do
-      config = described_class.new(ignore_patterns: ["call{name=log}"], skip_config_file: true)
-
-      expect(config.ignore_patterns).to eq(["call{name=log}"])
-    end
-
-    it "rejects non-string elements" do
-      expect { described_class.new(ignore_patterns: [123], skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /ignore_patterns must be an array of strings/)
-    end
-
-    it "rejects hash elements" do
-      expect { described_class.new(ignore_patterns: [{ name: "log" }], skip_config_file: true) }
-        .to raise_error(Evilution::ConfigError, /ignore_patterns must be an array of strings/)
-    end
-  end
-
-  describe "example_targeting" do
+  describe "example_targeting (orchestration)" do
     around do |example|
       original = ENV.fetch("EV_DISABLE_EXAMPLE_TARGETING", :__unset__)
       ENV.delete("EV_DISABLE_EXAMPLE_TARGETING")
@@ -802,7 +504,7 @@ RSpec.describe Evilution::Config do
       expect(config.example_targeting?).to be true
     end
 
-    it "accepts false" do
+    it "accepts false explicitly" do
       config = described_class.new(example_targeting: false, skip_config_file: true)
 
       expect(config.example_targeting?).to be false
@@ -827,44 +529,9 @@ RSpec.describe Evilution::Config do
         end
       end
     end
-
-    it "is disabled when EV_DISABLE_EXAMPLE_TARGETING=1 in env" do
-      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = "1"
-
-      expect(described_class.new(skip_config_file: true).example_targeting?).to be false
-    end
-
-    it "env overrides file config" do
-      Dir.mktmpdir do |dir|
-        Dir.chdir(dir) do
-          File.write(".evilution.yml", "example_targeting: true\n")
-          ENV["EV_DISABLE_EXAMPLE_TARGETING"] = "1"
-
-          expect(described_class.new.example_targeting?).to be false
-        end
-      end
-    end
-
-    it "CLI options override env var" do
-      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = "1"
-
-      expect(described_class.new(example_targeting: true, skip_config_file: true).example_targeting?).to be true
-    end
-
-    it "ignores empty env var" do
-      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = ""
-
-      expect(described_class.new(skip_config_file: true).example_targeting?).to be true
-    end
-
-    it "ignores env var set to 0" do
-      ENV["EV_DISABLE_EXAMPLE_TARGETING"] = "0"
-
-      expect(described_class.new(skip_config_file: true).example_targeting?).to be true
-    end
   end
 
-  describe "example_targeting_fallback" do
+  describe "example_targeting_fallback (orchestration)" do
     it "defaults to :full_file" do
       config = described_class.new(skip_config_file: true)
 
@@ -873,12 +540,6 @@ RSpec.describe Evilution::Config do
 
     it "accepts :unresolved" do
       config = described_class.new(example_targeting_fallback: :unresolved, skip_config_file: true)
-
-      expect(config.example_targeting_fallback).to eq(:unresolved)
-    end
-
-    it "accepts string and converts to symbol" do
-      config = described_class.new(example_targeting_fallback: "unresolved", skip_config_file: true)
 
       expect(config.example_targeting_fallback).to eq(:unresolved)
     end
@@ -892,27 +553,9 @@ RSpec.describe Evilution::Config do
         end
       end
     end
-
-    it "rejects invalid values" do
-      expect do
-        described_class.new(example_targeting_fallback: :invalid, skip_config_file: true)
-      end.to raise_error(Evilution::ConfigError, /example_targeting_fallback must be/)
-    end
-
-    it "rejects nil" do
-      expect do
-        described_class.new(example_targeting_fallback: nil, skip_config_file: true)
-      end.to raise_error(Evilution::ConfigError, /example_targeting_fallback must be/)
-    end
-
-    it "rejects integer with ConfigError (not NoMethodError)" do
-      expect do
-        described_class.new(example_targeting_fallback: 42, skip_config_file: true)
-      end.to raise_error(Evilution::ConfigError, /example_targeting_fallback must be/)
-    end
   end
 
-  describe "example_targeting_cache" do
+  describe "example_targeting_cache (orchestration)" do
     it "defaults to { max_files: 50, max_blocks: 10000 }" do
       config = described_class.new(skip_config_file: true)
 
@@ -949,30 +592,6 @@ RSpec.describe Evilution::Config do
           expect(described_class.new.example_targeting_cache).to eq(max_files: 25, max_blocks: 5_000)
         end
       end
-    end
-
-    it "rejects non-hash values" do
-      expect do
-        described_class.new(example_targeting_cache: "nope", skip_config_file: true)
-      end.to raise_error(Evilution::ConfigError, /example_targeting_cache must be a Hash/)
-    end
-
-    it "rejects non-positive max_files" do
-      expect do
-        described_class.new(example_targeting_cache: { max_files: 0 }, skip_config_file: true)
-      end.to raise_error(Evilution::ConfigError, /max_files must be a positive integer/)
-    end
-
-    it "rejects non-positive max_blocks" do
-      expect do
-        described_class.new(example_targeting_cache: { max_blocks: -1 }, skip_config_file: true)
-      end.to raise_error(Evilution::ConfigError, /max_blocks must be a positive integer/)
-    end
-
-    it "rejects non-string/symbol keys with ConfigError (not NoMethodError)" do
-      expect do
-        described_class.new(example_targeting_cache: { 42 => 1 }, skip_config_file: true)
-      end.to raise_error(Evilution::ConfigError, /example_targeting_cache keys must be/)
     end
   end
 


### PR DESCRIPTION
- Implemented validators for hooks, ignore patterns, integration, isolation, jobs, preload, spec mappings, and spec pattern.
- Each validator includes tests to ensure correct behavior for valid and invalid inputs.
- Updated the main config spec to include tests for new defaults and behaviors.
- Ensured that all validators raise appropriate errors for invalid configurations.