### PR TITLE
847: Add CLI line formatters and corresponding specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,6 @@ Metrics/ClassLength:
   Exclude:
     - "lib/evilution/integration/rspec.rb"
     - "lib/evilution/runner/mutation_executor.rb"
-    - "lib/evilution/reporter/cli.rb"
 
 Metrics/ModuleLength:
   Exclude:

--- a/lib/evilution/reporter/cli.rb
+++ b/lib/evilution/reporter/cli.rb
@@ -5,172 +5,88 @@ require_relative "../reporter"
 class Evilution::Reporter::CLI
   SEPARATOR = "=" * 44
 
+  def initialize(
+    header: LineFormatters::Header.new,
+    metrics_block: MetricsBlock.new,
+    section_renderer: SectionRenderer.new,
+    sections: DEFAULT_SECTIONS,
+    trailer: Trailer.new
+  )
+    @header = header
+    @metrics_block = metrics_block
+    @section_renderer = section_renderer
+    @sections = sections
+    @trailer = trailer
+  end
+
   def call(summary)
     lines = []
-    append_metrics(lines, summary)
-    append_sections(lines, summary)
-    lines << ""
-    lines << "[TRUNCATED] Stopped early due to --fail-fast" if summary.truncated?
-    lines << result_line(summary)
-    lines.join("\n")
-  end
-
-  private
-
-  def append_metrics(lines, summary)
-    lines << header
+    lines << @header.format(summary)
     lines << SEPARATOR
     lines << ""
-    lines << mutations_line(summary)
-    lines << score_line(summary)
-    lines << duration_line(summary)
-    lines << efficiency_line(summary) if summary.duration.positive?
-    peak = summary.peak_memory_mb
-    lines << peak_memory_line(peak) if peak
-  end
-
-  def append_sections(lines, summary)
-    append_survived(lines, summary)
-    append_neutral(lines, summary)
-    append_equivalent(lines, summary)
-    append_unresolved(lines, summary)
-    append_unparseable(lines, summary)
-    append_errors(lines, summary)
-    append_disabled(lines, summary)
-  end
-
-  def append_survived(lines, summary)
-    gaps = summary.coverage_gaps
-    return unless gaps.any?
-
+    lines.concat(@metrics_block.call(summary))
+    @sections.each { |section| lines.concat(@section_renderer.call(section, summary)) }
     lines << ""
-    lines << "Survived mutations (#{gaps.length} coverage gap#{"s" unless gaps.length == 1}):"
-    gaps.each { |gap| lines << format_coverage_gap(gap) }
-  end
-
-  def append_neutral(lines, summary)
-    return unless summary.neutral_results.any?
-
-    lines << ""
-    lines << "Neutral mutations (test already failing):"
-    summary.neutral_results.each { |result| lines << format_neutral(result) }
-  end
-
-  def append_equivalent(lines, summary)
-    return unless summary.equivalent_results.any?
-
-    lines << ""
-    lines << "Equivalent mutations (provably identical behavior):"
-    summary.equivalent_results.each { |result| lines << format_neutral(result) }
-  end
-
-  def append_unresolved(lines, summary)
-    return unless summary.unresolved_results.any?
-
-    lines << ""
-    lines << "Unresolved mutations (no test file resolved):"
-    summary.unresolved_results.each { |result| lines << format_neutral(result) }
-  end
-
-  def append_unparseable(lines, summary)
-    return unless summary.unparseable_results.any?
-
-    lines << ""
-    lines << "Unparseable mutations (mutated source did not parse):"
-    summary.unparseable_results.each { |result| lines << format_neutral(result) }
-  end
-
-  def append_errors(lines, summary)
-    errored = summary.results.select(&:error?)
-    return if errored.empty?
-
-    lines << ""
-    lines << "Errored mutations:"
-    errored.each { |result| lines << format_error(result) }
-  end
-
-  def format_error(result)
-    mutation = result.mutation
-    header = "  #{mutation.operator_name}: #{mutation.file_path}:#{mutation.line}"
-    return header unless result.error_message
-
-    indented = result.error_message.lines.map { |line| "    #{line.chomp}" }.join("\n")
-    "#{header}\n#{indented}"
-  end
-
-  def append_disabled(lines, summary)
-    return unless summary.disabled_mutations.any?
-
-    lines << ""
-    lines << "Disabled mutations (skipped by # evilution:disable):"
-    summary.disabled_mutations.each { |mutation| lines << format_disabled(mutation) }
-  end
-
-  def header
-    "Evilution v#{Evilution::VERSION} — Mutation Testing Results"
-  end
-
-  def mutations_line(summary)
-    parts = "Mutations: #{summary.total} total, #{summary.killed} killed, " \
-            "#{summary.survived} survived, #{summary.timed_out} timed out"
-    parts += ", #{summary.neutral} neutral" if summary.neutral.positive?
-    parts += ", #{summary.equivalent} equivalent" if summary.equivalent.positive?
-    parts += ", #{summary.unresolved} unresolved" if summary.unresolved.positive?
-    parts += ", #{summary.unparseable} unparseable" if summary.unparseable.positive?
-    parts += ", #{summary.skipped} skipped" if summary.skipped.positive?
-    parts
-  end
-
-  def score_line(summary)
-    score_pct = format_pct(summary.score)
-    "Score: #{score_pct} (#{summary.killed}/#{summary.score_denominator})"
-  end
-
-  def duration_line(summary)
-    "Duration: #{format("%.2f", summary.duration)}s"
-  end
-
-  def efficiency_line(summary)
-    pct = format("%.2f%%", summary.efficiency * 100)
-    rate = format("%.2f", summary.mutations_per_second)
-    "Efficiency: #{pct} killtime, #{rate} mutations/s"
-  end
-
-  def format_coverage_gap(gap)
-    location = "#{gap.file_path}:#{gap.line}"
-    header = if gap.single?
-               "  #{gap.primary_operator}: #{location} (#{gap.subject_name})"
-             else
-               operators = gap.operator_names.join(", ")
-               "  #{location} (#{gap.subject_name}) [#{gap.count} mutations: #{operators}]"
-             end
-    body = gap.mutation_results.first.mutation.unified_diff || gap.primary_diff
-    indented = body.split("\n").map { |l| "    #{l}" }.join("\n")
-    "#{header}\n#{indented}"
-  end
-
-  def format_neutral(result)
-    mutation = result.mutation
-    "  #{mutation.operator_name}: #{mutation.file_path}:#{mutation.line}"
-  end
-
-  def format_disabled(mutation)
-    "  #{mutation.operator_name}: #{mutation.file_path}:#{mutation.line}"
-  end
-
-  def result_line(summary)
-    min_score = 0.8
-    pass_fail = summary.success?(min_score: min_score) ? "PASS" : "FAIL"
-    score_pct = format_pct(summary.score)
-    threshold_pct = format_pct(min_score)
-    "Result: #{pass_fail} (score #{score_pct} #{pass_fail == "PASS" ? ">=" : "<"} #{threshold_pct})"
-  end
-
-  def peak_memory_line(peak_mb)
-    format("Peak memory: %<mb>.1f MB", mb: peak_mb)
-  end
-
-  def format_pct(value)
-    format("%.2f%%", value * 100)
+    lines.concat(@trailer.call(summary))
+    lines.join("\n")
   end
 end
+
+require_relative "cli/pct"
+require_relative "cli/section"
+require_relative "cli/section_renderer"
+require_relative "cli/line_formatters/header"
+require_relative "cli/line_formatters/mutations"
+require_relative "cli/line_formatters/score"
+require_relative "cli/line_formatters/duration"
+require_relative "cli/line_formatters/efficiency"
+require_relative "cli/line_formatters/peak_memory"
+require_relative "cli/line_formatters/truncation_notice"
+require_relative "cli/line_formatters/result_line"
+require_relative "cli/item_formatters/coverage_gap"
+require_relative "cli/item_formatters/result_location"
+require_relative "cli/item_formatters/error"
+require_relative "cli/item_formatters/disabled"
+require_relative "cli/metrics_block"
+require_relative "cli/trailer"
+
+Evilution::Reporter::CLI.const_set(
+  :DEFAULT_SECTIONS,
+  [
+    Evilution::Reporter::CLI::Section.new(
+      title: ->(gaps) { "Survived mutations (#{gaps.length} coverage gap#{"s" unless gaps.length == 1}):" },
+      fetcher: lambda(&:coverage_gaps),
+      formatter: Evilution::Reporter::CLI::ItemFormatters::CoverageGap.new
+    ),
+    Evilution::Reporter::CLI::Section.new(
+      title: "Neutral mutations (test already failing):",
+      fetcher: lambda(&:neutral_results),
+      formatter: Evilution::Reporter::CLI::ItemFormatters::ResultLocation.new
+    ),
+    Evilution::Reporter::CLI::Section.new(
+      title: "Equivalent mutations (provably identical behavior):",
+      fetcher: lambda(&:equivalent_results),
+      formatter: Evilution::Reporter::CLI::ItemFormatters::ResultLocation.new
+    ),
+    Evilution::Reporter::CLI::Section.new(
+      title: "Unresolved mutations (no test file resolved):",
+      fetcher: lambda(&:unresolved_results),
+      formatter: Evilution::Reporter::CLI::ItemFormatters::ResultLocation.new
+    ),
+    Evilution::Reporter::CLI::Section.new(
+      title: "Unparseable mutations (mutated source did not parse):",
+      fetcher: lambda(&:unparseable_results),
+      formatter: Evilution::Reporter::CLI::ItemFormatters::ResultLocation.new
+    ),
+    Evilution::Reporter::CLI::Section.new(
+      title: "Errored mutations:",
+      fetcher: ->(s) { s.results.select(&:error?) },
+      formatter: Evilution::Reporter::CLI::ItemFormatters::Error.new
+    ),
+    Evilution::Reporter::CLI::Section.new(
+      title: "Disabled mutations (skipped by # evilution:disable):",
+      fetcher: lambda(&:disabled_mutations),
+      formatter: Evilution::Reporter::CLI::ItemFormatters::Disabled.new
+    )
+  ].freeze
+)

--- a/lib/evilution/reporter/cli/item_formatters.rb
+++ b/lib/evilution/reporter/cli/item_formatters.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative "../cli"
+
+module Evilution::Reporter::CLI::ItemFormatters
+end

--- a/lib/evilution/reporter/cli/item_formatters/coverage_gap.rb
+++ b/lib/evilution/reporter/cli/item_formatters/coverage_gap.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../item_formatters"
+
+class Evilution::Reporter::CLI::ItemFormatters::CoverageGap
+  def format(gap)
+    location = "#{gap.file_path}:#{gap.line}"
+    header = if gap.single?
+               "  #{gap.primary_operator}: #{location} (#{gap.subject_name})"
+             else
+               operators = gap.operator_names.join(", ")
+               "  #{location} (#{gap.subject_name}) [#{gap.count} mutations: #{operators}]"
+             end
+    body = gap.mutation_results.first.mutation.unified_diff || gap.primary_diff
+    indented = body.split("\n").map { |l| "    #{l}" }.join("\n")
+    "#{header}\n#{indented}"
+  end
+end

--- a/lib/evilution/reporter/cli/item_formatters/disabled.rb
+++ b/lib/evilution/reporter/cli/item_formatters/disabled.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "../item_formatters"
+
+class Evilution::Reporter::CLI::ItemFormatters::Disabled
+  def format(mutation)
+    "  #{mutation.operator_name}: #{mutation.file_path}:#{mutation.line}"
+  end
+end

--- a/lib/evilution/reporter/cli/item_formatters/error.rb
+++ b/lib/evilution/reporter/cli/item_formatters/error.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../item_formatters"
+
+class Evilution::Reporter::CLI::ItemFormatters::Error
+  def format(result)
+    mutation = result.mutation
+    header = "  #{mutation.operator_name}: #{mutation.file_path}:#{mutation.line}"
+    return header unless result.error_message
+
+    indented = result.error_message.lines.map { |line| "    #{line.chomp}" }.join("\n")
+    "#{header}\n#{indented}"
+  end
+end

--- a/lib/evilution/reporter/cli/item_formatters/result_location.rb
+++ b/lib/evilution/reporter/cli/item_formatters/result_location.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "../item_formatters"
+
+class Evilution::Reporter::CLI::ItemFormatters::ResultLocation
+  def format(result)
+    mutation = result.mutation
+    "  #{mutation.operator_name}: #{mutation.file_path}:#{mutation.line}"
+  end
+end

--- a/lib/evilution/reporter/cli/line_formatters.rb
+++ b/lib/evilution/reporter/cli/line_formatters.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require_relative "../cli"
+
+module Evilution::Reporter::CLI::LineFormatters
+end

--- a/lib/evilution/reporter/cli/line_formatters/duration.rb
+++ b/lib/evilution/reporter/cli/line_formatters/duration.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "../line_formatters"
+
+class Evilution::Reporter::CLI::LineFormatters::Duration
+  def format(summary)
+    "Duration: #{Kernel.format("%.2f", summary.duration)}s"
+  end
+end

--- a/lib/evilution/reporter/cli/line_formatters/efficiency.rb
+++ b/lib/evilution/reporter/cli/line_formatters/efficiency.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../line_formatters"
+require_relative "../pct"
+
+class Evilution::Reporter::CLI::LineFormatters::Efficiency
+  def initialize(pct: Evilution::Reporter::CLI::Pct.new)
+    @pct = pct
+  end
+
+  def format(summary)
+    return nil unless summary.duration.positive?
+
+    pct = @pct.format(summary.efficiency)
+    rate = Kernel.format("%.2f", summary.mutations_per_second)
+    "Efficiency: #{pct} killtime, #{rate} mutations/s"
+  end
+end

--- a/lib/evilution/reporter/cli/line_formatters/header.rb
+++ b/lib/evilution/reporter/cli/line_formatters/header.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative "../line_formatters"
+require_relative "../../../version"
+
+class Evilution::Reporter::CLI::LineFormatters::Header
+  def format(_summary)
+    "Evilution v#{Evilution::VERSION} — Mutation Testing Results"
+  end
+end

--- a/lib/evilution/reporter/cli/line_formatters/mutations.rb
+++ b/lib/evilution/reporter/cli/line_formatters/mutations.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../line_formatters"
+
+class Evilution::Reporter::CLI::LineFormatters::Mutations
+  def format(summary)
+    parts = "Mutations: #{summary.total} total, #{summary.killed} killed, " \
+            "#{summary.survived} survived, #{summary.timed_out} timed out"
+    parts += ", #{summary.neutral} neutral" if summary.neutral.positive?
+    parts += ", #{summary.equivalent} equivalent" if summary.equivalent.positive?
+    parts += ", #{summary.unresolved} unresolved" if summary.unresolved.positive?
+    parts += ", #{summary.unparseable} unparseable" if summary.unparseable.positive?
+    parts += ", #{summary.skipped} skipped" if summary.skipped.positive?
+    parts
+  end
+end

--- a/lib/evilution/reporter/cli/line_formatters/peak_memory.rb
+++ b/lib/evilution/reporter/cli/line_formatters/peak_memory.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "../line_formatters"
+
+class Evilution::Reporter::CLI::LineFormatters::PeakMemory
+  def format(summary)
+    peak = summary.peak_memory_mb
+    return nil unless peak
+
+    Kernel.format("Peak memory: %<mb>.1f MB", mb: peak)
+  end
+end

--- a/lib/evilution/reporter/cli/line_formatters/result_line.rb
+++ b/lib/evilution/reporter/cli/line_formatters/result_line.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../line_formatters"
+require_relative "../pct"
+
+class Evilution::Reporter::CLI::LineFormatters::ResultLine
+  DEFAULT_MIN_SCORE = 0.8
+
+  def initialize(pct: Evilution::Reporter::CLI::Pct.new, min_score: DEFAULT_MIN_SCORE)
+    @pct = pct
+    @min_score = min_score
+  end
+
+  def format(summary)
+    pass_fail = summary.success?(min_score: @min_score) ? "PASS" : "FAIL"
+    score_pct = @pct.format(summary.score)
+    threshold_pct = @pct.format(@min_score)
+    "Result: #{pass_fail} (score #{score_pct} #{pass_fail == "PASS" ? ">=" : "<"} #{threshold_pct})"
+  end
+end

--- a/lib/evilution/reporter/cli/line_formatters/score.rb
+++ b/lib/evilution/reporter/cli/line_formatters/score.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative "../line_formatters"
+require_relative "../pct"
+
+class Evilution::Reporter::CLI::LineFormatters::Score
+  def initialize(pct: Evilution::Reporter::CLI::Pct.new)
+    @pct = pct
+  end
+
+  def format(summary)
+    "Score: #{@pct.format(summary.score)} (#{summary.killed}/#{summary.score_denominator})"
+  end
+end

--- a/lib/evilution/reporter/cli/line_formatters/truncation_notice.rb
+++ b/lib/evilution/reporter/cli/line_formatters/truncation_notice.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "../line_formatters"
+
+class Evilution::Reporter::CLI::LineFormatters::TruncationNotice
+  def format(summary)
+    return nil unless summary.truncated?
+
+    "[TRUNCATED] Stopped early due to --fail-fast"
+  end
+end

--- a/lib/evilution/reporter/cli/metrics_block.rb
+++ b/lib/evilution/reporter/cli/metrics_block.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../cli"
+require_relative "line_formatters/mutations"
+require_relative "line_formatters/score"
+require_relative "line_formatters/duration"
+require_relative "line_formatters/efficiency"
+require_relative "line_formatters/peak_memory"
+
+class Evilution::Reporter::CLI::MetricsBlock
+  DEFAULT_LINES = [
+    Evilution::Reporter::CLI::LineFormatters::Mutations.new,
+    Evilution::Reporter::CLI::LineFormatters::Score.new,
+    Evilution::Reporter::CLI::LineFormatters::Duration.new,
+    Evilution::Reporter::CLI::LineFormatters::Efficiency.new,
+    Evilution::Reporter::CLI::LineFormatters::PeakMemory.new
+  ].freeze
+
+  def initialize(lines: DEFAULT_LINES)
+    @lines = lines
+  end
+
+  def call(summary)
+    @lines.filter_map { |line| line.format(summary) }
+  end
+end

--- a/lib/evilution/reporter/cli/pct.rb
+++ b/lib/evilution/reporter/cli/pct.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "../cli"
+
+class Evilution::Reporter::CLI::Pct
+  def format(value)
+    Kernel.format("%.2f%%", value * 100)
+  end
+end

--- a/lib/evilution/reporter/cli/section.rb
+++ b/lib/evilution/reporter/cli/section.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../cli"
+
+class Evilution::Reporter::CLI::Section
+  attr_reader :title, :fetcher, :formatter
+
+  def initialize(title:, fetcher:, formatter:)
+    @title = title
+    @fetcher = fetcher
+    @formatter = formatter
+  end
+end

--- a/lib/evilution/reporter/cli/section_renderer.rb
+++ b/lib/evilution/reporter/cli/section_renderer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../cli"
+
+class Evilution::Reporter::CLI::SectionRenderer
+  def call(section, summary)
+    items = section.fetcher.call(summary)
+    return [] if items.empty?
+
+    title = section.title.respond_to?(:call) ? section.title.call(items) : section.title
+    lines = ["", title]
+    items.each { |item| lines << section.formatter.format(item) }
+    lines
+  end
+end

--- a/lib/evilution/reporter/cli/trailer.rb
+++ b/lib/evilution/reporter/cli/trailer.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../cli"
+require_relative "line_formatters/truncation_notice"
+require_relative "line_formatters/result_line"
+
+class Evilution::Reporter::CLI::Trailer
+  DEFAULT_LINES = [
+    Evilution::Reporter::CLI::LineFormatters::TruncationNotice.new,
+    Evilution::Reporter::CLI::LineFormatters::ResultLine.new
+  ].freeze
+
+  def initialize(lines: DEFAULT_LINES)
+    @lines = lines
+  end
+
+  def call(summary)
+    @lines.filter_map { |line| line.format(summary) }
+  end
+end

--- a/spec/evilution/reporter/cli/fixtures/cli_golden_complete.txt
+++ b/spec/evilution/reporter/cli/fixtures/cli_golden_complete.txt
@@ -1,0 +1,42 @@
+Evilution v0.26.0 — Mutation Testing Results
+============================================
+
+Mutations: 10 total, 8 killed, 1 survived, 0 timed out, 1 neutral, 1 equivalent, 1 unresolved, 1 unparseable, 1 skipped
+Score: 85.00% (8/10)
+Duration: 2.50s
+Efficiency: 34.00% killtime, 4.00 mutations/s
+Peak memory: 120.5 MB
+
+Survived mutations (2 coverage gaps):
+  BooleanFlip: lib/foo.rb:12 (Foo#bar)
+    @@ -1,1 +1,1 @@
+    -true
+    +false
+  lib/baz.rb:7 (Baz#qux) [2 mutations: ArithmeticReplace, ConstantReplace]
+    @@ -2,2 +2,2 @@
+    -x + 1
+    +x - 1
+
+Neutral mutations (test already failing):
+  StatementDeletion: lib/n.rb:3
+
+Equivalent mutations (provably identical behavior):
+  ScalarReturn: lib/e.rb:5
+
+Unresolved mutations (no test file resolved):
+  BooleanFlip: lib/u.rb:8
+
+Unparseable mutations (mutated source did not parse):
+  MethodBody: lib/p.rb:11
+
+Errored mutations:
+  ArithmeticReplace: lib/err.rb:22
+    RuntimeError: kaboom
+      at lib/err.rb:22
+      at lib/err.rb:30
+  ConstantReplace: lib/err2.rb:4
+
+Disabled mutations (skipped by # evilution:disable):
+  BooleanFlip: lib/disabled.rb:99
+
+Result: PASS (score 85.00% >= 80.00%)

--- a/spec/evilution/reporter/cli/fixtures/cli_golden_complete.txt
+++ b/spec/evilution/reporter/cli/fixtures/cli_golden_complete.txt
@@ -1,8 +1,8 @@
-Evilution v0.26.0 — Mutation Testing Results
+Evilution vEVILUTION_VERSION — Mutation Testing Results
 ============================================
 
-Mutations: 10 total, 8 killed, 1 survived, 0 timed out, 1 neutral, 1 equivalent, 1 unresolved, 1 unparseable, 1 skipped
-Score: 85.00% (8/10)
+Mutations: 16 total, 8 killed, 2 survived, 0 timed out, 1 neutral, 1 equivalent, 1 unresolved, 1 unparseable, 1 skipped
+Score: 80.00% (8/10)
 Duration: 2.50s
 Efficiency: 34.00% killtime, 4.00 mutations/s
 Peak memory: 120.5 MB
@@ -39,4 +39,4 @@ Errored mutations:
 Disabled mutations (skipped by # evilution:disable):
   BooleanFlip: lib/disabled.rb:99
 
-Result: PASS (score 85.00% >= 80.00%)
+Result: PASS (score 80.00% >= 80.00%)

--- a/spec/evilution/reporter/cli/fixtures/cli_golden_truncated.txt
+++ b/spec/evilution/reporter/cli/fixtures/cli_golden_truncated.txt
@@ -1,8 +1,8 @@
-Evilution v0.26.0 — Mutation Testing Results
+Evilution vEVILUTION_VERSION — Mutation Testing Results
 ============================================
 
-Mutations: 10 total, 8 killed, 1 survived, 0 timed out, 1 neutral, 1 equivalent, 1 unresolved, 1 unparseable, 1 skipped
-Score: 85.00% (8/10)
+Mutations: 16 total, 8 killed, 2 survived, 0 timed out, 1 neutral, 1 equivalent, 1 unresolved, 1 unparseable, 1 skipped
+Score: 80.00% (8/10)
 Duration: 2.50s
 Efficiency: 34.00% killtime, 4.00 mutations/s
 Peak memory: 120.5 MB
@@ -40,4 +40,4 @@ Disabled mutations (skipped by # evilution:disable):
   BooleanFlip: lib/disabled.rb:99
 
 [TRUNCATED] Stopped early due to --fail-fast
-Result: PASS (score 85.00% >= 80.00%)
+Result: PASS (score 80.00% >= 80.00%)

--- a/spec/evilution/reporter/cli/fixtures/cli_golden_truncated.txt
+++ b/spec/evilution/reporter/cli/fixtures/cli_golden_truncated.txt
@@ -1,0 +1,43 @@
+Evilution v0.26.0 — Mutation Testing Results
+============================================
+
+Mutations: 10 total, 8 killed, 1 survived, 0 timed out, 1 neutral, 1 equivalent, 1 unresolved, 1 unparseable, 1 skipped
+Score: 85.00% (8/10)
+Duration: 2.50s
+Efficiency: 34.00% killtime, 4.00 mutations/s
+Peak memory: 120.5 MB
+
+Survived mutations (2 coverage gaps):
+  BooleanFlip: lib/foo.rb:12 (Foo#bar)
+    @@ -1,1 +1,1 @@
+    -true
+    +false
+  lib/baz.rb:7 (Baz#qux) [2 mutations: ArithmeticReplace, ConstantReplace]
+    @@ -2,2 +2,2 @@
+    -x + 1
+    +x - 1
+
+Neutral mutations (test already failing):
+  StatementDeletion: lib/n.rb:3
+
+Equivalent mutations (provably identical behavior):
+  ScalarReturn: lib/e.rb:5
+
+Unresolved mutations (no test file resolved):
+  BooleanFlip: lib/u.rb:8
+
+Unparseable mutations (mutated source did not parse):
+  MethodBody: lib/p.rb:11
+
+Errored mutations:
+  ArithmeticReplace: lib/err.rb:22
+    RuntimeError: kaboom
+      at lib/err.rb:22
+      at lib/err.rb:30
+  ConstantReplace: lib/err2.rb:4
+
+Disabled mutations (skipped by # evilution:disable):
+  BooleanFlip: lib/disabled.rb:99
+
+[TRUNCATED] Stopped early due to --fail-fast
+Result: PASS (score 85.00% >= 80.00%)

--- a/spec/evilution/reporter/cli/golden_output_spec.rb
+++ b/spec/evilution/reporter/cli/golden_output_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli"
+require_relative "../../../support/fixtures/cli_golden_summary"
+
+RSpec.describe Evilution::Reporter::CLI do
+  describe "byte-for-byte output preservation" do
+    it "matches the golden output for a complete summary" do
+      summary = CliGoldenSummary.call
+      output = described_class.new.call(summary)
+      expected = File.read(
+        File.expand_path("fixtures/cli_golden_complete.txt", __dir__)
+      )
+      expect(output).to eq(expected)
+    end
+
+    it "matches the golden output for a truncated summary" do
+      summary = CliGoldenSummary.call(truncated: true)
+      output = described_class.new.call(summary)
+      expected = File.read(
+        File.expand_path("fixtures/cli_golden_truncated.txt", __dir__)
+      )
+      expect(output).to eq(expected)
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/golden_output_spec.rb
+++ b/spec/evilution/reporter/cli/golden_output_spec.rb
@@ -2,26 +2,30 @@
 
 require "spec_helper"
 require "evilution/reporter/cli"
+require "evilution/version"
 require_relative "../../../support/fixtures/cli_golden_summary"
 
 RSpec.describe Evilution::Reporter::CLI do
   describe "byte-for-byte output preservation" do
+    # Golden fixtures use the literal token `EVILUTION_VERSION` where the
+    # current `Evilution::VERSION` would appear, so version bumps don't force
+    # us to regenerate the committed `.txt` files. The substitution happens
+    # at read time, against the in-memory expected string only.
+    def read_golden(name)
+      File.read(File.expand_path("fixtures/#{name}", __dir__))
+          .gsub("EVILUTION_VERSION", Evilution::VERSION)
+    end
+
     it "matches the golden output for a complete summary" do
       summary = CliGoldenSummary.call
       output = described_class.new.call(summary)
-      expected = File.read(
-        File.expand_path("fixtures/cli_golden_complete.txt", __dir__)
-      )
-      expect(output).to eq(expected)
+      expect(output).to eq(read_golden("cli_golden_complete.txt"))
     end
 
     it "matches the golden output for a truncated summary" do
       summary = CliGoldenSummary.call(truncated: true)
       output = described_class.new.call(summary)
-      expected = File.read(
-        File.expand_path("fixtures/cli_golden_truncated.txt", __dir__)
-      )
-      expect(output).to eq(expected)
+      expect(output).to eq(read_golden("cli_golden_truncated.txt"))
     end
   end
 end

--- a/spec/evilution/reporter/cli/item_formatters/coverage_gap_spec.rb
+++ b/spec/evilution/reporter/cli/item_formatters/coverage_gap_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/item_formatters/coverage_gap"
+
+RSpec.describe Evilution::Reporter::CLI::ItemFormatters::CoverageGap do
+  describe "#format" do
+    let(:mutation) { double("mutation", unified_diff: "-old\n+new") }
+    let(:result) { double("result", mutation: mutation) }
+
+    it "formats a single-mutation gap with operator name and location" do
+      gap = double(
+        "gap",
+        single?: true,
+        primary_operator: "binary_swap",
+        file_path: "lib/foo.rb",
+        line: 42,
+        subject_name: "Foo#bar",
+        mutation_results: [result],
+        primary_diff: "-old\n+new"
+      )
+      out = described_class.new.format(gap)
+      expect(out).to eq("  binary_swap: lib/foo.rb:42 (Foo#bar)\n    -old\n    +new")
+    end
+
+    it "formats a multi-mutation gap with operator list and count" do
+      gap = double(
+        "gap",
+        single?: false,
+        operator_names: %w[binary_swap literal_replace],
+        file_path: "lib/foo.rb",
+        line: 42,
+        subject_name: "Foo#bar",
+        count: 2,
+        mutation_results: [result],
+        primary_diff: "-old\n+new"
+      )
+      out = described_class.new.format(gap)
+      expect(out).to eq("  lib/foo.rb:42 (Foo#bar) [2 mutations: binary_swap, literal_replace]\n    -old\n    +new")
+    end
+
+    it "falls back to primary_diff when first result has no unified_diff" do
+      no_diff_mutation = double("mutation", unified_diff: nil)
+      no_diff_result = double("result", mutation: no_diff_mutation)
+      gap = double(
+        "gap",
+        single?: true,
+        primary_operator: "x",
+        file_path: "f",
+        line: 1,
+        subject_name: "S",
+        mutation_results: [no_diff_result],
+        primary_diff: "fallback-diff"
+      )
+      out = described_class.new.format(gap)
+      expect(out).to include("fallback-diff")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/item_formatters/disabled_spec.rb
+++ b/spec/evilution/reporter/cli/item_formatters/disabled_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/item_formatters/disabled"
+
+RSpec.describe Evilution::Reporter::CLI::ItemFormatters::Disabled do
+  describe "#format" do
+    it "formats a Mutation directly as '  operator: file:line'" do
+      mutation = double("mutation", operator_name: "binary_swap", file_path: "lib/y.rb", line: 7)
+      expect(described_class.new.format(mutation)).to eq("  binary_swap: lib/y.rb:7")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/item_formatters/error_spec.rb
+++ b/spec/evilution/reporter/cli/item_formatters/error_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/item_formatters/error"
+
+RSpec.describe Evilution::Reporter::CLI::ItemFormatters::Error do
+  describe "#format" do
+    let(:mutation) { double("mutation", operator_name: "x", file_path: "f.rb", line: 1) }
+
+    it "returns header alone when error_message is nil" do
+      result = double("result", mutation: mutation, error_message: nil)
+      expect(described_class.new.format(result)).to eq("  x: f.rb:1")
+    end
+
+    it "appends indented error_message when present" do
+      result = double("result", mutation: mutation, error_message: "first line\nsecond line")
+      out = described_class.new.format(result)
+      expect(out).to eq("  x: f.rb:1\n    first line\n    second line")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/item_formatters/result_location_spec.rb
+++ b/spec/evilution/reporter/cli/item_formatters/result_location_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/item_formatters/result_location"
+
+RSpec.describe Evilution::Reporter::CLI::ItemFormatters::ResultLocation do
+  describe "#format" do
+    it "formats result.mutation as '  operator: file:line'" do
+      mutation = double("mutation", operator_name: "literal_swap", file_path: "lib/x.rb", line: 100)
+      result = double("result", mutation: mutation)
+      expect(described_class.new.format(result)).to eq("  literal_swap: lib/x.rb:100")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/line_formatters/duration_spec.rb
+++ b/spec/evilution/reporter/cli/line_formatters/duration_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/line_formatters/duration"
+
+RSpec.describe Evilution::Reporter::CLI::LineFormatters::Duration do
+  describe "#format" do
+    it "formats integer duration with 2 decimals" do
+      expect(described_class.new.format(double("s", duration: 5))).to eq("Duration: 5.00s")
+    end
+
+    it "formats float duration with 2 decimals" do
+      expect(described_class.new.format(double("s", duration: 2.5))).to eq("Duration: 2.50s")
+    end
+
+    it "rounds to 2 decimals" do
+      expect(described_class.new.format(double("s", duration: 1.234))).to eq("Duration: 1.23s")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/line_formatters/efficiency_spec.rb
+++ b/spec/evilution/reporter/cli/line_formatters/efficiency_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/line_formatters/efficiency"
+
+RSpec.describe Evilution::Reporter::CLI::LineFormatters::Efficiency do
+  describe "#format" do
+    it "returns nil when duration is not positive" do
+      expect(described_class.new.format(double("s", duration: 0))).to be_nil
+      expect(described_class.new.format(double("s", duration: 0.0))).to be_nil
+    end
+
+    it "uses default Pct when duration is positive" do
+      summary = double("s", duration: 2.5, efficiency: 0.34, mutations_per_second: 4.0)
+      expect(described_class.new.format(summary)).to eq("Efficiency: 34.00% killtime, 4.00 mutations/s")
+    end
+
+    it "uses injected Pct" do
+      pct = double("pct")
+      allow(pct).to receive(:format).with(0.34).and_return("X%")
+      summary = double("s", duration: 2.5, efficiency: 0.34, mutations_per_second: 4.0)
+      expect(described_class.new(pct: pct).format(summary)).to eq("Efficiency: X% killtime, 4.00 mutations/s")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/line_formatters/header_spec.rb
+++ b/spec/evilution/reporter/cli/line_formatters/header_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/line_formatters/header"
+require "evilution/version"
+
+RSpec.describe Evilution::Reporter::CLI::LineFormatters::Header do
+  describe "#format" do
+    it "returns the version + branding line" do
+      summary = double("summary")
+      expect(described_class.new.format(summary)).to eq(
+        "Evilution v#{Evilution::VERSION} — Mutation Testing Results"
+      )
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/line_formatters/mutations_spec.rb
+++ b/spec/evilution/reporter/cli/line_formatters/mutations_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/line_formatters/mutations"
+
+RSpec.describe Evilution::Reporter::CLI::LineFormatters::Mutations do
+  let(:summary) do
+    double(
+      "summary",
+      total: 10, killed: 8, survived: 1, timed_out: 1,
+      neutral: 0, equivalent: 0, unresolved: 0, unparseable: 0, skipped: 0
+    )
+  end
+
+  describe "#format" do
+    it "returns base line when all conditional categories are zero" do
+      expect(described_class.new.format(summary)).to eq(
+        "Mutations: 10 total, 8 killed, 1 survived, 1 timed out"
+      )
+    end
+
+    it "appends neutral when positive" do
+      allow(summary).to receive(:neutral).and_return(2)
+      expect(described_class.new.format(summary)).to include(", 2 neutral")
+    end
+
+    it "appends equivalent when positive" do
+      allow(summary).to receive(:equivalent).and_return(3)
+      expect(described_class.new.format(summary)).to include(", 3 equivalent")
+    end
+
+    it "appends unresolved when positive" do
+      allow(summary).to receive(:unresolved).and_return(4)
+      expect(described_class.new.format(summary)).to include(", 4 unresolved")
+    end
+
+    it "appends unparseable when positive" do
+      allow(summary).to receive(:unparseable).and_return(5)
+      expect(described_class.new.format(summary)).to include(", 5 unparseable")
+    end
+
+    it "appends skipped when positive" do
+      allow(summary).to receive(:skipped).and_return(6)
+      expect(described_class.new.format(summary)).to include(", 6 skipped")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/line_formatters/peak_memory_spec.rb
+++ b/spec/evilution/reporter/cli/line_formatters/peak_memory_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/line_formatters/peak_memory"
+
+RSpec.describe Evilution::Reporter::CLI::LineFormatters::PeakMemory do
+  describe "#format" do
+    it "returns nil when peak_memory_mb is nil" do
+      expect(described_class.new.format(double("s", peak_memory_mb: nil))).to be_nil
+    end
+
+    it "formats with 1 decimal when peak_memory_mb is set" do
+      expect(described_class.new.format(double("s", peak_memory_mb: 120.5))).to eq("Peak memory: 120.5 MB")
+    end
+
+    it "rounds to 1 decimal" do
+      expect(described_class.new.format(double("s", peak_memory_mb: 120.55))).to eq("Peak memory: 120.6 MB")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/line_formatters/result_line_spec.rb
+++ b/spec/evilution/reporter/cli/line_formatters/result_line_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/line_formatters/result_line"
+
+RSpec.describe Evilution::Reporter::CLI::LineFormatters::ResultLine do
+  describe "DEFAULT_MIN_SCORE" do
+    it "is 0.8" do
+      expect(described_class::DEFAULT_MIN_SCORE).to eq(0.8)
+    end
+  end
+
+  describe "#format" do
+    let(:passing) do
+      summary = double("s", score: 0.85)
+      allow(summary).to receive(:success?).with(min_score: 0.8).and_return(true)
+      summary
+    end
+
+    let(:failing) do
+      summary = double("s", score: 0.5)
+      allow(summary).to receive(:success?).with(min_score: 0.8).and_return(false)
+      summary
+    end
+
+    it "outputs PASS with >= when summary passes default threshold" do
+      expect(described_class.new.format(passing)).to eq("Result: PASS (score 85.00% >= 80.00%)")
+    end
+
+    it "outputs FAIL with < when summary fails default threshold" do
+      expect(described_class.new.format(failing)).to eq("Result: FAIL (score 50.00% < 80.00%)")
+    end
+
+    it "uses injected min_score" do
+      summary = double("s", score: 0.6)
+      allow(summary).to receive(:success?).with(min_score: 0.5).and_return(true)
+      expect(described_class.new(min_score: 0.5).format(summary)).to eq("Result: PASS (score 60.00% >= 50.00%)")
+    end
+
+    it "uses injected Pct" do
+      pct = double("pct")
+      allow(pct).to receive(:format).with(0.85).and_return("Spct")
+      allow(pct).to receive(:format).with(0.8).and_return("Tpct")
+      expect(described_class.new(pct: pct).format(passing)).to eq("Result: PASS (score Spct >= Tpct)")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/line_formatters/score_spec.rb
+++ b/spec/evilution/reporter/cli/line_formatters/score_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/line_formatters/score"
+
+RSpec.describe Evilution::Reporter::CLI::LineFormatters::Score do
+  describe "#format" do
+    let(:summary) { double("summary", score: 0.85, killed: 17, score_denominator: 20) }
+
+    it "uses default Pct" do
+      expect(described_class.new.format(summary)).to eq("Score: 85.00% (17/20)")
+    end
+
+    it "uses injected Pct" do
+      pct = double("pct")
+      allow(pct).to receive(:format).with(0.85).and_return("X%")
+      expect(described_class.new(pct: pct).format(summary)).to eq("Score: X% (17/20)")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/line_formatters/truncation_notice_spec.rb
+++ b/spec/evilution/reporter/cli/line_formatters/truncation_notice_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/line_formatters/truncation_notice"
+
+RSpec.describe Evilution::Reporter::CLI::LineFormatters::TruncationNotice do
+  describe "#format" do
+    it "returns nil when summary.truncated? is false" do
+      expect(described_class.new.format(double("s", truncated?: false))).to be_nil
+    end
+
+    it "returns the notice line when summary.truncated? is true" do
+      expect(described_class.new.format(double("s", truncated?: true))).to eq(
+        "[TRUNCATED] Stopped early due to --fail-fast"
+      )
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/metrics_block_spec.rb
+++ b/spec/evilution/reporter/cli/metrics_block_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/metrics_block"
+
+RSpec.describe Evilution::Reporter::CLI::MetricsBlock do
+  describe "#call" do
+    it "returns nil-filtered formatted lines from configured formatters" do
+      summary = double("summary")
+      f1 = double("f1")
+      allow(f1).to receive(:format).with(summary).and_return("line-1")
+      f2 = double("f2")
+      allow(f2).to receive(:format).with(summary).and_return(nil)
+      f3 = double("f3")
+      allow(f3).to receive(:format).with(summary).and_return("line-3")
+      block = described_class.new(lines: [f1, f2, f3])
+      expect(block.call(summary)).to eq(%w[line-1 line-3])
+    end
+  end
+
+  describe "DEFAULT_LINES" do
+    it "is a frozen array of LineFormatter instances" do
+      expect(described_class::DEFAULT_LINES).to be_frozen
+      described_class::DEFAULT_LINES.each do |line|
+        expect(line).to respond_to(:format)
+      end
+    end
+
+    it "contains 5 default formatters in the canonical order" do
+      classes = described_class::DEFAULT_LINES.map(&:class)
+      expect(classes).to eq([Evilution::Reporter::CLI::LineFormatters::Mutations,
+                             Evilution::Reporter::CLI::LineFormatters::Score,
+                             Evilution::Reporter::CLI::LineFormatters::Duration,
+                             Evilution::Reporter::CLI::LineFormatters::Efficiency,
+                             Evilution::Reporter::CLI::LineFormatters::PeakMemory])
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/pct_spec.rb
+++ b/spec/evilution/reporter/cli/pct_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/pct"
+
+RSpec.describe Evilution::Reporter::CLI::Pct do
+  describe "#format" do
+    it "formats a 0..1 value as percent with 2 decimals" do
+      expect(described_class.new.format(0.5)).to eq("50.00%")
+      expect(described_class.new.format(0.123)).to eq("12.30%")
+      expect(described_class.new.format(0.0)).to eq("0.00%")
+      expect(described_class.new.format(1.0)).to eq("100.00%")
+    end
+
+    it "rounds to 2 decimals" do
+      # Matches legacy `format("%.2f%%", value * 100)` behavior in cli.rb
+      # (Kernel#format uses round-half-to-even on the IEEE-754 representation).
+      expect(described_class.new.format(0.12355)).to eq("12.36%")
+      expect(described_class.new.format(0.12344)).to eq("12.34%")
+    end
+
+    it "supports >100% values" do
+      expect(described_class.new.format(1.5)).to eq("150.00%")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/section_renderer_spec.rb
+++ b/spec/evilution/reporter/cli/section_renderer_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/section"
+require "evilution/reporter/cli/section_renderer"
+
+RSpec.describe Evilution::Reporter::CLI::SectionRenderer do
+  describe "#call" do
+    let(:formatter) { instance_double("ItemFormatter") }
+    let(:summary) { double("summary", items: %i[a b]) }
+
+    it "returns [] when fetcher returns empty array" do
+      section = Evilution::Reporter::CLI::Section.new(
+        title: "Things:",
+        fetcher: ->(_) { [] },
+        formatter: formatter
+      )
+      expect(described_class.new.call(section, summary)).to eq([])
+    end
+
+    it "returns ['', title, formatter.format(item) for each item] for non-empty fetch" do
+      allow(formatter).to receive(:format).with(:a).and_return("  a-line")
+      allow(formatter).to receive(:format).with(:b).and_return("  b-line")
+      section = Evilution::Reporter::CLI::Section.new(
+        title: "Things:",
+        fetcher: lambda(&:items),
+        formatter: formatter
+      )
+      expect(described_class.new.call(section, summary)).to eq([
+                                                                 "",
+                                                                 "Things:",
+                                                                 "  a-line",
+                                                                 "  b-line"
+                                                               ])
+    end
+
+    it "calls a callable title with the items array" do
+      allow(formatter).to receive(:format).and_return("  x")
+      section = Evilution::Reporter::CLI::Section.new(
+        title: ->(items) { "Found #{items.length}:" },
+        fetcher: ->(_) { [1, 2, 3] },
+        formatter: formatter
+      )
+      result = described_class.new.call(section, summary)
+      expect(result[1]).to eq("Found 3:")
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/section_spec.rb
+++ b/spec/evilution/reporter/cli/section_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/section"
+
+RSpec.describe Evilution::Reporter::CLI::Section do
+  describe "#initialize" do
+    it "stores title, fetcher, formatter as readers" do
+      formatter = double("formatter")
+      fetcher = ->(s) { s }
+      title = "Hello:"
+      section = described_class.new(title: title, fetcher: fetcher, formatter: formatter)
+      expect(section.title).to eq(title)
+      expect(section.fetcher).to eq(fetcher)
+      expect(section.formatter).to eq(formatter)
+    end
+
+    it "accepts a callable title (lambda taking items)" do
+      title = ->(items) { "Found #{items.length}:" }
+      section = described_class.new(title: title, fetcher: ->(_) {}, formatter: double("f"))
+      expect(section.title).to eq(title)
+    end
+  end
+end

--- a/spec/evilution/reporter/cli/trailer_spec.rb
+++ b/spec/evilution/reporter/cli/trailer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/reporter/cli/trailer"
+
+RSpec.describe Evilution::Reporter::CLI::Trailer do
+  describe "#call" do
+    it "returns nil-filtered lines from configured formatters" do
+      summary = double("summary")
+      f1 = double("f1")
+      allow(f1).to receive(:format).with(summary).and_return(nil)
+      f2 = double("f2")
+      allow(f2).to receive(:format).with(summary).and_return("trailer-line")
+      trailer = described_class.new(lines: [f1, f2])
+      expect(trailer.call(summary)).to eq(["trailer-line"])
+    end
+  end
+
+  describe "DEFAULT_LINES" do
+    it "is a frozen array containing TruncationNotice and ResultLine instances" do
+      expect(described_class::DEFAULT_LINES).to be_frozen
+      classes = described_class::DEFAULT_LINES.map(&:class)
+      expect(classes).to eq([Evilution::Reporter::CLI::LineFormatters::TruncationNotice,
+                             Evilution::Reporter::CLI::LineFormatters::ResultLine])
+    end
+  end
+end

--- a/spec/evilution/reporter/cli_spec.rb
+++ b/spec/evilution/reporter/cli_spec.rb
@@ -1,562 +1,108 @@
 # frozen_string_literal: true
 
+require "spec_helper"
 require "evilution/reporter/cli"
-require "evilution/result/mutation_result"
 require "evilution/result/summary"
+require_relative "../../support/fixtures/cli_golden_summary"
 
+# Public API + smoke tests for the CLI reporter composition root.
+# Granular behavior is covered by:
+#   - spec/evilution/reporter/cli/golden_output_spec.rb (byte-equal regression)
+#   - spec/evilution/reporter/cli/{pct,section,section_renderer,metrics_block,trailer}_spec.rb
+#   - spec/evilution/reporter/cli/line_formatters/*
+#   - spec/evilution/reporter/cli/item_formatters/*
 RSpec.describe Evilution::Reporter::CLI do
-  subject(:reporter) { described_class.new }
+  let(:empty_summary) { Evilution::Result::Summary.new(results: [], duration: 0.0) }
 
-  let(:survived_mutation) do
-    subj = double("Subject", name: "User#check")
-    double(
-      "Mutation",
-      operator_name: "comparison_replacement",
-      file_path: "lib/user.rb",
-      line: 9,
-      diff: "- x >= 10\n+ x > 10",
-      unified_diff: "--- a/lib/user.rb\n+++ b/lib/user.rb\n@@ -9,1 +9,1 @@\n-x >= 10\n+x > 10",
-      subject: subj
-    )
+  describe "constants" do
+    it "exposes SEPARATOR as 44 equals signs" do
+      expect(described_class::SEPARATOR).to eq("=" * 44)
+    end
+
+    it "exposes DEFAULT_SECTIONS as a frozen array of 7 Section instances" do
+      expect(described_class::DEFAULT_SECTIONS).to be_frozen
+      expect(described_class::DEFAULT_SECTIONS.length).to eq(7)
+      described_class::DEFAULT_SECTIONS.each do |section|
+        expect(section).to be_a(described_class::Section)
+      end
+    end
   end
 
-  let(:killed_mutation) do
-    double(
-      "Mutation",
-      operator_name: "comparison_replacement",
-      file_path: "lib/user.rb",
-      line: 5,
-      diff: "- x == 10\n+ x != 10"
-    )
-  end
+  describe "#initialize" do
+    it "succeeds with no args (default composition)" do
+      expect { described_class.new }.not_to raise_error
+    end
 
-  let(:survived_result) do
-    Evilution::Result::MutationResult.new(
-      mutation: survived_mutation,
-      status: :survived,
-      duration: 0.123
-    )
-  end
-
-  let(:killed_result) do
-    Evilution::Result::MutationResult.new(
-      mutation: killed_mutation,
-      status: :killed,
-      duration: 0.456
-    )
-  end
-
-  let(:summary) do
-    Evilution::Result::Summary.new(
-      results: [survived_result, killed_result],
-      duration: 12.34
-    )
+    it "accepts header, metrics_block, section_renderer, sections, trailer kwargs" do
+      expect do
+        described_class.new(
+          header: instance_double(Evilution::Reporter::CLI::LineFormatters::Header, format: "H"),
+          metrics_block: instance_double(Evilution::Reporter::CLI::MetricsBlock, call: ["M"]),
+          section_renderer: instance_double(Evilution::Reporter::CLI::SectionRenderer),
+          sections: [],
+          trailer: instance_double(Evilution::Reporter::CLI::Trailer, call: ["T"])
+        )
+      end.not_to raise_error
+    end
   end
 
   describe "#call" do
-    it "includes the version in the header" do
-      output = reporter.call(summary)
-
-      expect(output).to include("Evilution v#{Evilution::VERSION}")
+    it "returns a String" do
+      expect(described_class.new.call(empty_summary)).to be_a(String)
     end
 
-    it "includes a separator line" do
-      output = reporter.call(summary)
+    it "renders header, separator, metrics, and trailer for an empty summary" do
+      output = described_class.new.call(empty_summary)
+      lines = output.split("\n")
 
-      expect(output).to include("=" * 44)
+      expect(lines[0]).to start_with("Evilution v")
+      expect(lines[1]).to eq("=" * 44)
+      expect(lines[2]).to eq("")
+      expect(output).to include("Mutations: ")
+      expect(output).to include("Score: ")
+      expect(output).to include("Duration: ")
+      expect(output).to include("Result: ")
     end
 
-    it "shows correct mutation counts" do
-      output = reporter.call(summary)
-
-      expect(output).to include("2 total")
-      expect(output).to include("1 killed")
-      expect(output).to include("1 survived")
-      expect(output).to include("0 timed out")
-    end
-
-    it "shows the score as a percentage with fraction" do
-      output = reporter.call(summary)
-
-      expect(output).to include("Score:")
-      expect(output).to include("50.00%")
-      expect(output).to include("(1/2)")
-    end
-
-    it "shows the duration in seconds" do
-      output = reporter.call(summary)
-
-      expect(output).to include("Duration: 12.34s")
-    end
-
-    it "shows efficiency metrics" do
-      output = reporter.call(summary)
-
-      expect(output).to match(%r{Efficiency: \d+\.\d+% killtime, \d+\.\d+ mutations/s})
-    end
-
-    it "calculates correct efficiency values" do
-      r1 = Evilution::Result::MutationResult.new(mutation: killed_mutation, status: :killed, duration: 3.0)
-      r2 = Evilution::Result::MutationResult.new(mutation: survived_mutation, status: :survived, duration: 2.0)
-      s = Evilution::Result::Summary.new(results: [r1, r2], duration: 10.0)
-
-      output = reporter.call(s)
-
-      expect(output).to include("Efficiency: 50.00% killtime, 0.20 mutations/s")
-    end
-
-    it "omits efficiency line when duration is zero" do
-      s = Evilution::Result::Summary.new(results: [killed_result], duration: 0.0)
-
-      output = reporter.call(s)
-
-      expect(output).not_to include("Efficiency:")
-    end
-
-    it "lists survived mutations with operator and location" do
-      output = reporter.call(summary)
-
-      expect(output).to include("Survived mutations (1 coverage gap):")
-      expect(output).to include("comparison_replacement: lib/user.rb:9")
-    end
-
-    it "shows the subject name for survived mutations" do
-      output = reporter.call(summary)
-
-      expect(output).to include("User#check")
-    end
-
-    it "shows a git-style unified diff header for survived mutations" do
-      output = reporter.call(summary)
-
-      expect(output).to include("--- a/lib/user.rb")
-      expect(output).to include("+++ b/lib/user.rb")
-      expect(output).to include("@@ -9,1 +9,1 @@")
-    end
-
-    it "shows the diff body for survived mutations in unified format" do
-      output = reporter.call(summary)
-
-      expect(output).to include("-x >= 10")
-      expect(output).to include("+x > 10")
-    end
-
-    it "indents the unified diff under the gap header" do
-      output = reporter.call(summary)
-
-      expect(output).to match(%r{^ {4}--- a/lib/user\.rb$})
-      expect(output).to match(/^ {4}@@ -9,1 \+9,1 @@$/)
-    end
-
-    context "with multi-line slices" do
-      let(:survived_mutation) do
-        subj = double("Subject", name: "User#check")
-        double(
-          "Mutation",
-          operator_name: "block_removal",
-          file_path: "lib/user.rb",
-          line: 12,
-          diff: "ignored",
-          unified_diff: "--- a/lib/user.rb\n+++ b/lib/user.rb\n@@ -12,3 +12,3 @@\n if cond\n-  do_a\n+  do_b\n end",
-          subject: subj
-        )
-      end
-
-      it "emits hunk lengths matching slice line counts" do
-        output = reporter.call(summary)
-
-        expect(output).to include("@@ -12,3 +12,3 @@")
-      end
-
-      it "renders unchanged lines as context with leading space" do
-        output = reporter.call(summary)
-
-        expect(output).to include(" if cond")
-        expect(output).to include("-  do_a")
-        expect(output).to include("+  do_b")
-        expect(output).to include(" end")
-      end
-    end
-
-    context "when slices are nil (legacy mutation)" do
-      let(:survived_mutation) do
-        subj = double("Subject", name: "User#check")
-        double(
-          "Mutation",
-          operator_name: "comparison_replacement",
-          file_path: "lib/user.rb",
-          line: 9,
-          diff: "- x >= 10\n+ x > 10",
-          unified_diff: nil,
-          subject: subj
-        )
-      end
-
-      it "falls back to legacy diff format" do
-        output = reporter.call(summary)
-
-        expect(output).to include("- x >= 10")
-        expect(output).to include("+ x > 10")
-        expect(output).not_to include("@@")
-      end
-    end
-
-    it "shows FAIL when score is below threshold" do
-      output = reporter.call(summary)
-
-      # score is 50%, below default 80% threshold
-      expect(output).to include("Result: FAIL")
-    end
-
-    it "shows PASS when score meets threshold" do
-      passing_summary = Evilution::Result::Summary.new(
-        results: [killed_result],
-        duration: 0.5
-      )
-      output = reporter.call(passing_summary)
-
-      expect(output).to include("Result: PASS")
-    end
-
-    it "includes the threshold percentage in the result line" do
-      output = reporter.call(summary)
-
-      expect(output).to include("80.00%")
-    end
-
-    context "with multiple survived mutations on the same line" do
-      let(:survived_mutation2) do
-        subj = double("Subject", name: "User#check")
-        double(
-          "Mutation",
-          operator_name: "method_call_removal",
-          file_path: "lib/user.rb",
-          line: 9,
-          diff: "- x >= 10\n+ nil",
-          subject: subj
-        )
-      end
-
-      let(:survived_result2) do
-        Evilution::Result::MutationResult.new(
-          mutation: survived_mutation2,
-          status: :survived,
-          duration: 0.2
-        )
-      end
-
-      let(:grouped_summary) do
-        Evilution::Result::Summary.new(
-          results: [survived_result, survived_result2, killed_result],
-          duration: 1.0
-        )
-      end
-
-      it "groups them into a single coverage gap" do
-        output = reporter.call(grouped_summary)
-
-        expect(output).to include("Survived mutations (1 coverage gap):")
-      end
-
-      it "shows the count and operators for grouped gaps" do
-        output = reporter.call(grouped_summary)
-
-        expect(output).to include("[2 mutations: comparison_replacement, method_call_removal]")
-      end
-
-      it "shows the location and subject for grouped gaps" do
-        output = reporter.call(grouped_summary)
-
-        expect(output).to include("lib/user.rb:9 (User#check)")
-      end
-    end
-
-    it "does not show survived mutations section when there are none" do
-      passing_summary = Evilution::Result::Summary.new(
-        results: [killed_result],
-        duration: 0.5
-      )
-      output = reporter.call(passing_summary)
+    it "omits all section headers when summary has no items in any section" do
+      output = described_class.new.call(empty_summary)
 
       expect(output).not_to include("Survived mutations")
+      expect(output).not_to include("Neutral mutations")
+      expect(output).not_to include("Equivalent mutations")
+      expect(output).not_to include("Unresolved mutations")
+      expect(output).not_to include("Unparseable mutations")
+      expect(output).not_to include("Errored mutations")
+      expect(output).not_to include("Disabled mutations")
     end
 
-    context "with neutral mutations" do
-      let(:neutral_mutation) do
-        double(
-          "Mutation",
-          operator_name: "comparison_replacement",
-          file_path: "lib/user.rb",
-          line: 12,
-          diff: "- x <= 5\n+ x < 5"
-        )
-      end
+    it "uses injected sections when provided (empty list produces no section output)" do
+      summary = CliGoldenSummary.call
+      output = described_class.new(sections: []).call(summary)
 
-      let(:neutral_result) do
-        Evilution::Result::MutationResult.new(
-          mutation: neutral_mutation,
-          status: :neutral,
-          duration: 0.1
-        )
-      end
-
-      let(:neutral_summary) do
-        Evilution::Result::Summary.new(
-          results: [killed_result, neutral_result],
-          duration: 1.0
-        )
-      end
-
-      it "includes neutral count in mutations line" do
-        output = reporter.call(neutral_summary)
-
-        expect(output).to include("1 neutral")
-      end
-
-      it "shows neutral mutations section" do
-        output = reporter.call(neutral_summary)
-
-        expect(output).to include("Neutral mutations (test already failing):")
-        expect(output).to include("comparison_replacement: lib/user.rb:12")
-      end
-
-      it "excludes neutrals from score denominator" do
-        output = reporter.call(neutral_summary)
-
-        expect(output).to include("Score:")
-        expect(output).to include("(1/1)")
-      end
-
-      it "does not show neutral section when there are none" do
-        output = reporter.call(summary)
-
-        expect(output).not_to include("Neutral mutations")
-      end
-    end
-
-    context "with unresolved mutations" do
-      let(:unresolved_mutation) do
-        double(
-          "Mutation",
-          operator_name: "integer_literal",
-          file_path: "lib/isolated.rb",
-          line: 42,
-          diff: "- 1\n+ 2"
-        )
-      end
-
-      let(:unresolved_result) do
-        Evilution::Result::MutationResult.new(
-          mutation: unresolved_mutation,
-          status: :unresolved,
-          duration: 0.0
-        )
-      end
-
-      let(:unresolved_summary) do
-        Evilution::Result::Summary.new(
-          results: [killed_result, unresolved_result],
-          duration: 1.0
-        )
-      end
-
-      it "shows unresolved mutations section" do
-        output = reporter.call(unresolved_summary)
-
-        expect(output).to include("Unresolved mutations (no spec resolved):")
-        expect(output).to include("integer_literal: lib/isolated.rb:42")
-      end
-
-      it "does not show unresolved section when there are none" do
-        output = reporter.call(summary)
-
-        expect(output).not_to include("Unresolved mutations")
-      end
-    end
-
-    context "with unparseable mutations" do
-      let(:unparseable_mutation) do
-        double(
-          "Mutation",
-          operator_name: "method_body_replacement",
-          file_path: "lib/broken.rb",
-          line: 7,
-          diff: "- def foo; end\n+ def foo; raise; end"
-        )
-      end
-
-      let(:unparseable_result) do
-        Evilution::Result::MutationResult.new(
-          mutation: unparseable_mutation,
-          status: :unparseable,
-          duration: 0.0
-        )
-      end
-
-      let(:unparseable_summary) do
-        Evilution::Result::Summary.new(
-          results: [killed_result, unparseable_result],
-          duration: 1.0
-        )
-      end
-
-      it "includes unparseable count in mutations line" do
-        output = reporter.call(unparseable_summary)
-
-        expect(output).to include("1 unparseable")
-      end
-
-      it "shows unparseable mutations section" do
-        output = reporter.call(unparseable_summary)
-
-        expect(output).to include("Unparseable mutations (mutated source did not parse):")
-        expect(output).to include("method_body_replacement: lib/broken.rb:7")
-      end
-
-      it "does not show unparseable section when there are none" do
-        output = reporter.call(summary)
-
-        expect(output).not_to include("Unparseable mutations")
-        expect(output).not_to include("unparseable")
-      end
-
-      it "excludes unparseable from score denominator" do
-        output = reporter.call(unparseable_summary)
-
-        expect(output).to include("(1/1)")
-      end
-    end
-
-    it "handles empty results gracefully" do
-      empty_summary = Evilution::Result::Summary.new(results: [], duration: 0.0)
-      output = reporter.call(empty_summary)
-
-      expect(output).to include("0 total")
-      expect(output).to include("0 killed")
-      expect(output).to include("0 survived")
+      expect(output).to include("Result: ")
       expect(output).not_to include("Survived mutations")
+      expect(output).not_to include("Neutral mutations")
+      expect(output).not_to include("Errored mutations")
     end
 
-    it "shows truncation notice when summary is truncated" do
-      truncated_summary = Evilution::Result::Summary.new(
-        results: [survived_result],
-        duration: 0.5,
-        truncated: true
-      )
-      output = reporter.call(truncated_summary)
+    it "renders the [TRUNCATED] line when summary.truncated? is true" do
+      truncated_summary = Evilution::Result::Summary.new(results: [], duration: 0.0, truncated: true)
+      output = described_class.new.call(truncated_summary)
 
       expect(output).to include("[TRUNCATED] Stopped early due to --fail-fast")
     end
 
-    it "does not show truncation notice when summary is not truncated" do
-      output = reporter.call(summary)
+    it "exercises the full section pipeline end-to-end on a comprehensive summary" do
+      output = described_class.new.call(CliGoldenSummary.call)
 
-      expect(output).not_to include("TRUNCATED")
-    end
-
-    context "with skipped mutations" do
-      let(:skipped_summary) do
-        Evilution::Result::Summary.new(
-          results: [killed_result],
-          duration: 1.0,
-          skipped: 3
-        )
-      end
-
-      it "includes skipped count in mutations line" do
-        output = reporter.call(skipped_summary)
-
-        expect(output).to include("3 skipped")
-      end
-
-      it "does not show skipped when count is zero" do
-        output = reporter.call(summary)
-
-        expect(output).not_to include("skipped")
-      end
-    end
-
-    context "with disabled mutations" do
-      let(:disabled_mutation) do
-        double(
-          "Mutation",
-          operator_name: "boolean_literal_replacement",
-          file_path: "lib/user.rb",
-          line: 15
-        )
-      end
-
-      let(:disabled_summary) do
-        Evilution::Result::Summary.new(
-          results: [killed_result],
-          duration: 1.0,
-          disabled_mutations: [disabled_mutation]
-        )
-      end
-
-      it "shows disabled mutations section" do
-        output = reporter.call(disabled_summary)
-
-        expect(output).to include("Disabled mutations (skipped by # evilution:disable):")
-        expect(output).to include("boolean_literal_replacement: lib/user.rb:15")
-      end
-
-      it "does not show disabled section when empty" do
-        output = reporter.call(summary)
-
-        expect(output).not_to include("Disabled mutations")
-      end
-    end
-
-    context "with errored mutations" do
-      let(:error_result) do
-        Evilution::Result::MutationResult.new(
-          mutation: killed_mutation,
-          status: :error,
-          duration: 0.05,
-          error_message: "syntax error in mutated source: unexpected token"
-        )
-      end
-
-      let(:error_summary) do
-        Evilution::Result::Summary.new(
-          results: [killed_result, error_result],
-          duration: 1.0
-        )
-      end
-
-      it "shows errored mutations section with error message" do
-        output = reporter.call(error_summary)
-
-        expect(output).to include("Errored mutations:")
-        expect(output).to include("comparison_replacement: lib/user.rb:5")
-        expect(output).to include("syntax error in mutated source: unexpected token")
-      end
-
-      it "does not show errored section when empty" do
-        output = reporter.call(summary)
-
-        expect(output).not_to include("Errored mutations")
-      end
-
-      it "indents every line of a multi-line error message" do
-        multiline_result = Evilution::Result::MutationResult.new(
-          mutation: killed_mutation,
-          status: :error,
-          duration: 0.05,
-          error_message: "syntax error line 1\nunexpected token line 2\nand line 3"
-        )
-        multiline_summary = Evilution::Result::Summary.new(
-          results: [multiline_result],
-          duration: 1.0
-        )
-
-        output = reporter.call(multiline_summary)
-
-        expect(output).to include("    syntax error line 1")
-        expect(output).to include("    unexpected token line 2")
-        expect(output).to include("    and line 3")
-      end
+      expect(output).to include("Survived mutations")
+      expect(output).to include("Neutral mutations")
+      expect(output).to include("Equivalent mutations")
+      expect(output).to include("Unresolved mutations")
+      expect(output).to include("Unparseable mutations")
+      expect(output).to include("Errored mutations")
+      expect(output).to include("Disabled mutations")
     end
   end
 end

--- a/spec/support/fixtures/cli_golden_summary.rb
+++ b/spec/support/fixtures/cli_golden_summary.rb
@@ -36,19 +36,30 @@ module CliGoldenSummary
 
   module_function
 
+  # Field values mirror real `Evilution::Result::Summary` math:
+  #   total           = killed + survived + timed_out + neutral +
+  #                     equivalent + unresolved + unparseable + errors
+  #   score_denominator = total - errors - neutral - equivalent -
+  #                       unresolved - unparseable
+  #   score           = killed.to_f / score_denominator
+  # `skipped` is a separate counter (not part of `total`).
+  # `results` carries 3 entries (1 non-errored, 2 errored) only because the CLI
+  # uses it solely to drive `select(&:error?)`; we deliberately do not pad
+  # `results` to length 16 — its presence here is an input to the error filter,
+  # not the source of truth for `total`.
   def call(truncated: false)
     Summary.new(
-      10, # total
+      16, # total = 8 killed + 2 survived + 0 timed_out + 1 neutral + 1 equivalent + 1 unresolved + 1 unparseable + 2 errors
       8,  # killed
-      1,  # survived
+      2,  # survived
       0,  # timed_out
       1,  # neutral
       1,  # equivalent
       1,  # unresolved
       1,  # unparseable
-      1,  # skipped
-      0.85, # score
-      10,   # score_denominator
+      1,  # skipped (independent counter, not part of total)
+      0.8,  # score = killed (8) / score_denominator (10)
+      10,   # score_denominator = total (16) - errors (2) - neutral (1) - equivalent (1) - unresolved (1) - unparseable (1)
       2.5,  # duration
       0.34, # efficiency
       4.0,  # mutations_per_second

--- a/spec/support/fixtures/cli_golden_summary.rb
+++ b/spec/support/fixtures/cli_golden_summary.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# Deterministic synthetic Summary fixture used by the CLI golden-output spec.
+#
+# This fixture exercises every conditional branch of
+# `Evilution::Reporter::CLI#call` so that the captured output (committed in
+# spec/evilution/reporter/cli/fixtures/) acts as a byte-for-byte regression
+# net during the SOLID refactor (GH issue #847).
+#
+# IMPORTANT: All values are hard-coded. No Time.now, no rand, no env reads —
+# the fixture must produce identical output on every machine and run.
+#
+# rubocop:disable Metrics/ModuleLength
+module CliGoldenSummary
+  Mutation = Struct.new(:operator_name, :file_path, :line, :unified_diff)
+  Result = Struct.new(:mutation, :error?, :error_message)
+  # CoverageGap mirrors Evilution::Result::CoverageGap which exposes a `count`
+  # method; the CLI calls it directly so we must shadow Struct#count here.
+  # rubocop:disable Lint/StructNewOverride
+  CoverageGap = Struct.new(
+    :file_path, :line, :subject_name, :single?, :primary_operator,
+    :operator_names, :count, :mutation_results, :primary_diff
+  )
+  # rubocop:enable Lint/StructNewOverride
+  Summary = Struct.new(
+    :total, :killed, :survived, :timed_out, :neutral, :equivalent,
+    :unresolved, :unparseable, :skipped, :score, :score_denominator,
+    :duration, :efficiency, :mutations_per_second, :peak_memory_mb,
+    :coverage_gaps, :neutral_results, :equivalent_results, :unresolved_results,
+    :unparseable_results, :results, :disabled_mutations, :truncated?
+  ) do
+    def success?(min_score:)
+      score >= min_score
+    end
+  end
+
+  module_function
+
+  def call(truncated: false)
+    Summary.new(
+      10, # total
+      8,  # killed
+      1,  # survived
+      0,  # timed_out
+      1,  # neutral
+      1,  # equivalent
+      1,  # unresolved
+      1,  # unparseable
+      1,  # skipped
+      0.85, # score
+      10,   # score_denominator
+      2.5,  # duration
+      0.34, # efficiency
+      4.0,  # mutations_per_second
+      120.5, # peak_memory_mb
+      coverage_gaps,
+      neutral_results,
+      equivalent_results,
+      unresolved_results,
+      unparseable_results,
+      errored_results,
+      disabled_mutations,
+      truncated
+    ).freeze
+  end
+
+  def coverage_gaps
+    [single_gap, multi_gap].freeze
+  end
+
+  def single_gap
+    diff = "@@ -1,1 +1,1 @@\n-true\n+false"
+    survived_mutation = Mutation.new(
+      "BooleanFlip", "lib/foo.rb", 12,
+      "@@ -1,1 +1,1 @@\n-true\n+false"
+    )
+    survived_result = Result.new(survived_mutation, false, nil)
+    CoverageGap.new(
+      "lib/foo.rb", 12, "Foo#bar", true, "BooleanFlip",
+      ["BooleanFlip"], 1, [survived_result], diff
+    )
+  end
+
+  def multi_gap
+    diff = "@@ -2,2 +2,2 @@\n-x + 1\n+x - 1"
+    mutation_a = Mutation.new(
+      "ArithmeticReplace", "lib/baz.rb", 7,
+      "@@ -2,2 +2,2 @@\n-x + 1\n+x - 1"
+    )
+    mutation_b = Mutation.new(
+      "ConstantReplace", "lib/baz.rb", 7,
+      "@@ -2,2 +2,2 @@\n-x + 1\n+x * 2"
+    )
+    result_a = Result.new(mutation_a, false, nil)
+    result_b = Result.new(mutation_b, false, nil)
+    CoverageGap.new(
+      "lib/baz.rb", 7, "Baz#qux", false, "ArithmeticReplace",
+      %w[ArithmeticReplace ConstantReplace], 2, [result_a, result_b], diff
+    )
+  end
+
+  def neutral_results
+    [Result.new(Mutation.new("StatementDeletion", "lib/n.rb", 3, nil), false, nil)].freeze
+  end
+
+  def equivalent_results
+    [Result.new(Mutation.new("ScalarReturn", "lib/e.rb", 5, nil), false, nil)].freeze
+  end
+
+  def unresolved_results
+    [Result.new(Mutation.new("BooleanFlip", "lib/u.rb", 8, nil), false, nil)].freeze
+  end
+
+  def unparseable_results
+    [Result.new(Mutation.new("MethodBody", "lib/p.rb", 11, nil), false, nil)].freeze
+  end
+
+  # `summary.results` is filtered through `.select(&:error?)` by the CLI;
+  # we include a mix of errored and non-errored results so the filter has
+  # something to do, plus one errored result without an error_message to
+  # exercise the "return header unless result.error_message" branch.
+  def errored_results
+    [
+      Result.new(Mutation.new("BooleanFlip", "lib/ok.rb", 1, nil), false, nil),
+      Result.new(
+        Mutation.new("ArithmeticReplace", "lib/err.rb", 22, nil),
+        true,
+        "RuntimeError: kaboom\n  at lib/err.rb:22\n  at lib/err.rb:30"
+      ),
+      Result.new(
+        Mutation.new("ConstantReplace", "lib/err2.rb", 4, nil),
+        true,
+        nil
+      )
+    ].freeze
+  end
+
+  def disabled_mutations
+    [Mutation.new("BooleanFlip", "lib/disabled.rb", 99, nil)].freeze
+  end
+end
+# rubocop:enable Metrics/ModuleLength


### PR DESCRIPTION
- Implemented line formatters for header, mutations, peak memory, result line, score, truncation notice, and metrics block.
- Created specs for each line formatter to ensure correct output formatting.
- Introduced a comprehensive summary fixture for CLI golden output tests.
- Updated the CLI reporter to utilize new line formatters and ensure proper output for various mutation results.