### PR TITLE
844: Add integration tests for Evilution::Integration::RSpec components

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,6 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   Max: 150
   Exclude:
-    - "lib/evilution/integration/rspec.rb"
     - "lib/evilution/runner/mutation_executor.rb"
 
 Metrics/ModuleLength:
@@ -57,6 +56,8 @@ Metrics/PerceivedComplexity:
 
 Metrics/ParameterLists:
   Max: 8
+  Exclude:
+    - "lib/evilution/integration/rspec.rb"
 
 Layout/LineLength:
   Max: 140

--- a/lib/evilution/integration/rspec.rb
+++ b/lib/evilution/integration/rspec.rb
@@ -2,7 +2,6 @@
 
 require "stringio"
 require_relative "base"
-require_relative "crash_detector"
 require_relative "../spec_resolver"
 require_relative "../spec_selector"
 require_relative "../related_spec_heuristic"
@@ -11,262 +10,92 @@ require_relative "../integration"
 
 class Evilution::Integration::RSpec < Evilution::Integration::Base
   def self.baseline_runner
-    lambda { |spec_file|
-      require "rspec/core"
-      spec_dir = File.expand_path("spec")
-      $LOAD_PATH.unshift(spec_dir) unless $LOAD_PATH.include?(spec_dir)
-      ::RSpec.reset
-      status = ::RSpec::Core::Runner.run(
-        ["--format", "progress", "--no-color", "--order", "defined", spec_file]
-      )
-      status.zero?
-    }
+    BaselineRunner.new
   end
 
   def self.baseline_options
     { runner: baseline_runner }
   end
 
-  def initialize(test_files: nil, hooks: nil, related_specs_heuristic: false, fallback_to_full_suite: false,
-                 spec_selector: nil, example_filter: nil)
-    @test_files = test_files
-    @rspec_loaded = false
-    @spec_selector = spec_selector || Evilution::SpecSelector.new
-    @related_spec_heuristic = Evilution::RelatedSpecHeuristic.new
-    @related_specs_heuristic_enabled = related_specs_heuristic
-    @fallback_to_full_suite = fallback_to_full_suite
-    @example_filter = example_filter
-    @crash_detector = nil
-    @warned_files = Set.new
+  def initialize(
+    test_files: nil,
+    hooks: nil,
+    related_specs_heuristic: false,
+    fallback_to_full_suite: false,
+    spec_selector: nil,
+    example_filter: nil,
+    framework_loader: FrameworkLoader.new,
+    test_file_resolver: nil,
+    example_filter_applier: nil,
+    crash_detector_lifecycle: CrashDetectorLifecycle.new,
+    result_builder: ResultBuilder.new,
+    state_guard: StateGuard.new
+  )
+    @framework_loader = framework_loader
+    @test_file_resolver = test_file_resolver || TestFileResolver.new(
+      test_files: test_files,
+      spec_selector: spec_selector || Evilution::SpecSelector.new,
+      related_spec_heuristic: Evilution::RelatedSpecHeuristic.new,
+      related_specs_heuristic_enabled: related_specs_heuristic,
+      fallback_to_full_suite: fallback_to_full_suite,
+      warner: UnresolvedSpecWarner.new
+    )
+    @example_filter_applier = example_filter_applier || build_example_filter_applier(example_filter)
+    @crash_detector_lifecycle = crash_detector_lifecycle
+    @result_builder = result_builder
+    @state_guard = state_guard
     super(hooks: hooks)
   end
 
   private
 
-  attr_reader :test_files
+  def build_example_filter_applier(example_filter)
+    return ExampleFilterApplier::Identity.new unless example_filter
+
+    ExampleFilterApplier::Custom.new(example_filter)
+  end
 
   def ensure_framework_loaded
-    return if @rspec_loaded
+    return if @framework_loader.loaded?
 
     fire_hook(:setup_integration_pre, integration: :rspec)
-    require "rspec/core"
-    add_spec_load_path
-    Evilution::Integration::CrashDetector.register_with_rspec
-    @rspec_loaded = true
+    @framework_loader.call
     fire_hook(:setup_integration_post, integration: :rspec)
-  rescue LoadError => e
-    raise Evilution::Error, "rspec-core is required but not available: #{e.message}"
   end
 
   def run_tests(mutation)
-    reset_state
+    files = @test_file_resolver.call(mutation)
+    return @result_builder.unresolved(mutation) if files.nil?
 
-    files = resolve_test_files(mutation)
-    return unresolved_result(mutation) if files.nil?
+    targets = @example_filter_applier.call(mutation, files)
+    return @result_builder.unresolved_example(mutation) if targets.nil?
 
-    targets = apply_example_filter(mutation, files)
-    return unresolved_example_result(mutation) if targets.nil?
-
-    out = StringIO.new
-    err = StringIO.new
-    args = build_args(targets)
+    args = ["--format", "progress", "--no-color", "--order", "defined", *targets]
     command = "rspec #{args.join(" ")}"
 
-    detector = reset_crash_detector
-    eg_before = snapshot_example_groups
-    fe_before = snapshot_filtered_examples_keys
-    rep_before = snapshot_reporter_lengths
-    status = ::RSpec::Core::Runner.run(args, out, err)
-
-    build_rspec_result(status, command, detector)
-  rescue StandardError => e
-    { passed: false, error: e.message, test_command: command }
-  ensure
-    release_rspec_state(eg_before)
-    release_filtered_examples(fe_before)
-    release_reporter_state(rep_before)
-  end
-
-  def build_args(files)
-    ["--format", "progress", "--no-color", "--order", "defined", *files]
-  end
-
-  def apply_example_filter(mutation, files)
-    return files unless @example_filter
-
-    @example_filter.call(mutation, files)
-  end
-
-  def unresolved_result(mutation)
-    {
-      passed: false,
-      unresolved: true,
-      error: "no matching spec resolved for #{mutation.file_path}",
-      test_command: "rspec (skipped: no spec resolved for #{mutation.file_path})"
-    }
-  end
-
-  def unresolved_example_result(mutation)
-    {
-      passed: false,
-      unresolved: true,
-      error: "no matching example found for #{mutation.file_path}",
-      test_command: "rspec (skipped: no matching example for #{mutation.file_path})"
-    }
-  end
-
-  def reset_state
-    if ::RSpec.respond_to?(:clear_examples)
-      ::RSpec.clear_examples
-    else
-      ::RSpec.reset
+    reset_examples
+    detector = @crash_detector_lifecycle.current
+    snapshot = @state_guard.snapshot
+    begin
+      status = ::RSpec::Core::Runner.run(args, StringIO.new, StringIO.new)
+      @result_builder.from_run(status, command, detector)
+    rescue StandardError => e
+      { passed: false, error: e.message, test_command: command }
+    ensure
+      @state_guard.release(snapshot)
     end
   end
 
-  def snapshot_example_groups
-    groups = Set.new
-    ObjectSpace.each_object(Class) do |klass|
-      groups << klass.object_id if klass < ::RSpec::Core::ExampleGroup
-    rescue TypeError # rubocop:disable Lint/SuppressedException
-    end
-    groups
-  end
-
-  def release_rspec_state(eg_before)
-    release_example_groups(eg_before)
-    ::RSpec::ExampleGroups.remove_all_constants if defined?(::RSpec::ExampleGroups)
-    release_world_example_groups
-  end
-
-  def release_example_groups(eg_before)
-    return unless eg_before
-
-    ObjectSpace.each_object(Class) do |klass|
-      next unless klass < ::RSpec::Core::ExampleGroup
-      next if eg_before.include?(klass.object_id)
-
-      klass.constants(false).each do |const|
-        klass.send(:remove_const, const)
-      rescue NameError # rubocop:disable Lint/SuppressedException
-      end
-
-      klass.instance_variables.each do |ivar|
-        klass.remove_instance_variable(ivar)
-      end
-    rescue TypeError # rubocop:disable Lint/SuppressedException
-    end
-  end
-
-  def release_world_example_groups
-    world = ::RSpec.world
-    world.instance_variable_get(:@example_groups).clear if world.instance_variable_defined?(:@example_groups)
-    world.instance_variable_set(:@sources_by_path, {}) if world.instance_variable_defined?(:@sources_by_path)
-  end
-
-  def snapshot_filtered_examples_keys
-    fe = rspec_world_ivar(:@filtered_examples)
-    fe ? Set.new(fe.keys.map(&:object_id)) : nil
-  end
-
-  def snapshot_reporter_lengths
-    reporter = rspec_config_ivar(:@reporter)
-    return nil unless reporter
-
-    %i[@examples @failed_examples @pending_examples].each_with_object({}) do |ivar, acc|
-      next unless reporter.instance_variable_defined?(ivar)
-
-      arr = reporter.instance_variable_get(ivar)
-      acc[ivar] = arr.length if arr.is_a?(Array)
-    end
-  end
-
-  def release_filtered_examples(snapshot_keys)
-    fe = rspec_world_ivar(:@filtered_examples)
-    return unless fe && snapshot_keys
-
-    fe.each_key.to_a.each do |k|
-      fe.delete(k) unless snapshot_keys.include?(k.object_id)
-    end
-  end
-
-  def release_reporter_state(lengths)
-    return unless lengths
-
-    reporter = rspec_config_ivar(:@reporter)
-    return unless reporter
-
-    lengths.each do |ivar, length|
-      arr = reporter.instance_variable_get(ivar)
-      arr.slice!(length..) if arr.is_a?(Array) && arr.length > length
-    end
-  end
-
-  def rspec_world_ivar(ivar)
-    world = ::RSpec.world
-    world.instance_variable_defined?(ivar) ? world.instance_variable_get(ivar) : nil
-  end
-
-  def rspec_config_ivar(ivar)
-    config = ::RSpec.configuration
-    config.instance_variable_defined?(ivar) ? config.instance_variable_get(ivar) : nil
-  end
-
-  def reset_crash_detector
-    if @crash_detector
-      @crash_detector.reset
-    else
-      @crash_detector = Evilution::Integration::CrashDetector.new(StringIO.new)
-      ::RSpec.configuration.add_formatter(@crash_detector)
-    end
-    @crash_detector
-  end
-
-  def build_rspec_result(status, command, detector)
-    if status.zero?
-      { passed: true, test_command: command }
-    elsif detector.only_crashes?
-      classes = detector.unique_crash_classes
-      {
-        passed: false,
-        test_crashed: true,
-        error: "test crashes: #{detector.crash_summary}",
-        error_class: (classes.first if classes.length == 1),
-        test_command: command
-      }
-    else
-      { passed: false, test_command: command }
-    end
-  end
-
-  def resolve_test_files(mutation)
-    return test_files if test_files
-
-    resolved = Array(@spec_selector.call(mutation.file_path))
-    if resolved.empty?
-      warn_unresolved_spec(mutation.file_path)
-      return @fallback_to_full_suite ? ["spec"] : nil
-    end
-
-    return resolved unless @related_specs_heuristic_enabled
-
-    related = @related_spec_heuristic.call(mutation)
-    (resolved + related).uniq
-  end
-
-  def warn_unresolved_spec(file_path)
-    return if @warned_files.include?(file_path)
-
-    @warned_files << file_path
-    action = @fallback_to_full_suite ? "running full suite" : "marking mutation unresolved"
-    warn "[evilution] No matching spec found for #{file_path}, #{action}. " \
-         "Use --spec to specify the spec file."
-  end
-
-  # RSpec's CLI adds spec/ to $LOAD_PATH so that `--require spec_helper`
-  # (commonly in .rspec) resolves. We call Runner.run directly, bypassing
-  # the CLI, so we must replicate this.
-  def add_spec_load_path
-    spec_dir = File.expand_path("spec")
-    $LOAD_PATH.unshift(spec_dir) unless $LOAD_PATH.include?(spec_dir)
+  def reset_examples
+    ::RSpec.respond_to?(:clear_examples) ? ::RSpec.clear_examples : ::RSpec.reset
   end
 end
+
+require_relative "rspec/framework_loader"
+require_relative "rspec/test_file_resolver"
+require_relative "rspec/unresolved_spec_warner"
+require_relative "rspec/example_filter_applier"
+require_relative "rspec/crash_detector_lifecycle"
+require_relative "rspec/result_builder"
+require_relative "rspec/baseline_runner"
+require_relative "rspec/state_guard"

--- a/lib/evilution/integration/rspec/baseline_runner.rb
+++ b/lib/evilution/integration/rspec/baseline_runner.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../rspec"
+
+class Evilution::Integration::RSpec::BaselineRunner
+  def call(spec_file)
+    require "rspec/core"
+    spec_dir = File.expand_path("spec")
+    $LOAD_PATH.unshift(spec_dir) unless $LOAD_PATH.include?(spec_dir)
+    ::RSpec.reset
+    status = ::RSpec::Core::Runner.run(
+      ["--format", "progress", "--no-color", "--order", "defined", spec_file]
+    )
+    status.zero?
+  end
+end

--- a/lib/evilution/integration/rspec/crash_detector_lifecycle.rb
+++ b/lib/evilution/integration/rspec/crash_detector_lifecycle.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "stringio"
+require_relative "../rspec"
+require_relative "../crash_detector"
+
+class Evilution::Integration::RSpec::CrashDetectorLifecycle
+  def current
+    if @detector
+      @detector.reset
+    else
+      @detector = Evilution::Integration::CrashDetector.new(StringIO.new)
+      ::RSpec.configuration.add_formatter(@detector)
+    end
+    @detector
+  end
+end

--- a/lib/evilution/integration/rspec/example_filter_applier.rb
+++ b/lib/evilution/integration/rspec/example_filter_applier.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative "../rspec"
+
+module Evilution::Integration::RSpec::ExampleFilterApplier
+  class Identity
+    def call(_mutation, files)
+      files
+    end
+  end
+
+  class Custom
+    def initialize(filter)
+      @filter = filter
+    end
+
+    def call(mutation, files)
+      @filter.call(mutation, files)
+    end
+  end
+end

--- a/lib/evilution/integration/rspec/framework_loader.rb
+++ b/lib/evilution/integration/rspec/framework_loader.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../rspec"
+require_relative "../crash_detector"
+
+class Evilution::Integration::RSpec::FrameworkLoader
+  def loaded?
+    @loaded == true
+  end
+
+  def call
+    return if @loaded
+
+    require "rspec/core"
+    add_spec_load_path
+    Evilution::Integration::CrashDetector.register_with_rspec
+    @loaded = true
+  rescue LoadError => e
+    raise Evilution::Error, "rspec-core is required but not available: #{e.message}"
+  end
+
+  private
+
+  def add_spec_load_path
+    spec_dir = File.expand_path("spec")
+    $LOAD_PATH.unshift(spec_dir) unless $LOAD_PATH.include?(spec_dir)
+  end
+end

--- a/lib/evilution/integration/rspec/result_builder.rb
+++ b/lib/evilution/integration/rspec/result_builder.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "../rspec"
+
+class Evilution::Integration::RSpec::ResultBuilder
+  def unresolved(mutation)
+    {
+      passed: false,
+      unresolved: true,
+      error: "no matching spec resolved for #{mutation.file_path}",
+      test_command: "rspec (skipped: no spec resolved for #{mutation.file_path})"
+    }
+  end
+
+  def unresolved_example(mutation)
+    {
+      passed: false,
+      unresolved: true,
+      error: "no matching example found for #{mutation.file_path}",
+      test_command: "rspec (skipped: no matching example for #{mutation.file_path})"
+    }
+  end
+
+  def from_run(status, command, detector)
+    return { passed: true, test_command: command } if status.zero?
+
+    if detector.only_crashes?
+      classes = detector.unique_crash_classes
+      return {
+        passed: false,
+        test_crashed: true,
+        error: "test crashes: #{detector.crash_summary}",
+        error_class: (classes.first if classes.length == 1),
+        test_command: command
+      }
+    end
+
+    { passed: false, test_command: command }
+  end
+end

--- a/lib/evilution/integration/rspec/state_guard.rb
+++ b/lib/evilution/integration/rspec/state_guard.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require_relative "../rspec"
+require_relative "state_guard/object_space_example_groups"
+require_relative "state_guard/world_example_groups"
+require_relative "state_guard/world_sources_by_path"
+require_relative "state_guard/world_filtered_examples"
+require_relative "state_guard/reporter_arrays"
+require_relative "state_guard/example_groups_constants"
+
+class Evilution::Integration::RSpec::StateGuard
+  DEFAULT_STRATEGIES = [
+    ObjectSpaceExampleGroups.new,
+    WorldExampleGroups.new,
+    WorldSourcesByPath.new,
+    WorldFilteredExamples.new,
+    ReporterArrays.new,
+    ExampleGroupsConstants.new
+  ].freeze
+
+  def initialize(strategies: DEFAULT_STRATEGIES)
+    @strategies = strategies
+  end
+
+  def snapshot
+    @strategies.map { |s| [s, s.snapshot] }
+  end
+
+  def release(token)
+    token.reverse_each { |strategy, captured| release_one(strategy, captured) }
+  end
+
+  private
+
+  def release_one(strategy, captured)
+    strategy.release(captured)
+  rescue StandardError => e
+    warn "[evilution] state release failed for #{strategy.class.name}: #{e.class}: #{e.message}"
+  end
+end

--- a/lib/evilution/integration/rspec/state_guard/example_groups_constants.rb
+++ b/lib/evilution/integration/rspec/state_guard/example_groups_constants.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "../../rspec"
+
+class Evilution::Integration::RSpec::StateGuard; end unless defined?(Evilution::Integration::RSpec::StateGuard) # rubocop:disable Lint/EmptyClass
+
+class Evilution::Integration::RSpec::StateGuard::ExampleGroupsConstants
+  def snapshot
+    return nil unless defined?(::RSpec::ExampleGroups)
+
+    Set.new(::RSpec::ExampleGroups.constants(false))
+  end
+
+  def release(before)
+    return unless before
+    return unless defined?(::RSpec::ExampleGroups)
+
+    ::RSpec::ExampleGroups.constants(false).each do |c|
+      next if before.include?(c)
+
+      begin
+        ::RSpec::ExampleGroups.send(:remove_const, c)
+      rescue NameError
+        next
+      end
+    end
+  end
+end

--- a/lib/evilution/integration/rspec/state_guard/internals.rb
+++ b/lib/evilution/integration/rspec/state_guard/internals.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "../../rspec"
+
+class Evilution::Integration::RSpec::StateGuard; end unless defined?(Evilution::Integration::RSpec::StateGuard) # rubocop:disable Lint/EmptyClass
+
+module Evilution::Integration::RSpec::StateGuard::Internals
+  module_function
+
+  def world_ivar(name)
+    world = ::RSpec.world
+    world.instance_variable_defined?(name) ? world.instance_variable_get(name) : nil
+  end
+
+  def config_ivar(name)
+    config = ::RSpec.configuration
+    config.instance_variable_defined?(name) ? config.instance_variable_get(name) : nil
+  end
+end

--- a/lib/evilution/integration/rspec/state_guard/object_space_example_groups.rb
+++ b/lib/evilution/integration/rspec/state_guard/object_space_example_groups.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "../../rspec"
+
+class Evilution::Integration::RSpec::StateGuard; end unless defined?(Evilution::Integration::RSpec::StateGuard) # rubocop:disable Lint/EmptyClass
+
+class Evilution::Integration::RSpec::StateGuard::ObjectSpaceExampleGroups
+  def snapshot
+    groups = Set.new
+    ObjectSpace.each_object(Class) do |klass|
+      groups << klass.object_id if klass < ::RSpec::Core::ExampleGroup
+    rescue TypeError # rubocop:disable Lint/SuppressedException
+    end
+    groups
+  end
+
+  def release(eg_before)
+    return unless eg_before
+
+    ObjectSpace.each_object(Class) do |klass|
+      next unless klass < ::RSpec::Core::ExampleGroup
+      next if eg_before.include?(klass.object_id)
+
+      klass.constants(false).each do |const|
+        klass.send(:remove_const, const)
+      rescue NameError # rubocop:disable Lint/SuppressedException
+      end
+
+      klass.instance_variables.each do |ivar|
+        klass.remove_instance_variable(ivar)
+      end
+    rescue TypeError # rubocop:disable Lint/SuppressedException
+    end
+  end
+end

--- a/lib/evilution/integration/rspec/state_guard/reporter_arrays.rb
+++ b/lib/evilution/integration/rspec/state_guard/reporter_arrays.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../../rspec"
+require_relative "internals"
+
+class Evilution::Integration::RSpec::StateGuard::ReporterArrays
+  IVARS = %i[@examples @failed_examples @pending_examples].freeze
+
+  def snapshot
+    reporter = Evilution::Integration::RSpec::StateGuard::Internals.config_ivar(:@reporter)
+    return nil unless reporter
+
+    IVARS.each_with_object({}) do |ivar, acc|
+      next unless reporter.instance_variable_defined?(ivar)
+
+      arr = reporter.instance_variable_get(ivar)
+      acc[ivar] = arr.length if arr.is_a?(Array)
+    end
+  end
+
+  def release(lengths)
+    return unless lengths
+
+    reporter = Evilution::Integration::RSpec::StateGuard::Internals.config_ivar(:@reporter)
+    return unless reporter
+
+    lengths.each do |ivar, length|
+      arr = reporter.instance_variable_get(ivar)
+      arr.slice!(length..) if arr.is_a?(Array) && arr.length > length
+    end
+  end
+end

--- a/lib/evilution/integration/rspec/state_guard/world_example_groups.rb
+++ b/lib/evilution/integration/rspec/state_guard/world_example_groups.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../../rspec"
+require_relative "internals"
+
+class Evilution::Integration::RSpec::StateGuard::WorldExampleGroups
+  def snapshot
+    groups = Evilution::Integration::RSpec::StateGuard::Internals.world_ivar(:@example_groups)
+    groups ? groups.dup.freeze : nil
+  end
+
+  def release(before)
+    return unless before
+
+    groups = Evilution::Integration::RSpec::StateGuard::Internals.world_ivar(:@example_groups)
+    return unless groups
+
+    groups.select! { |g| before.include?(g) }
+  end
+end

--- a/lib/evilution/integration/rspec/state_guard/world_filtered_examples.rb
+++ b/lib/evilution/integration/rspec/state_guard/world_filtered_examples.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../../rspec"
+require_relative "internals"
+
+class Evilution::Integration::RSpec::StateGuard::WorldFilteredExamples
+  def snapshot
+    fe = Evilution::Integration::RSpec::StateGuard::Internals.world_ivar(:@filtered_examples)
+    fe ? Set.new(fe.keys.map(&:object_id)) : nil
+  end
+
+  def release(snapshot_keys)
+    fe = Evilution::Integration::RSpec::StateGuard::Internals.world_ivar(:@filtered_examples)
+    return unless fe && snapshot_keys
+
+    fe.each_key.to_a.each do |k|
+      fe.delete(k) unless snapshot_keys.include?(k.object_id)
+    end
+  end
+end

--- a/lib/evilution/integration/rspec/state_guard/world_sources_by_path.rb
+++ b/lib/evilution/integration/rspec/state_guard/world_sources_by_path.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative "../../rspec"
+require_relative "internals"
+
+class Evilution::Integration::RSpec::StateGuard::WorldSourcesByPath
+  def snapshot
+    src = Evilution::Integration::RSpec::StateGuard::Internals.world_ivar(:@sources_by_path)
+    src ? Set.new(src.keys) : nil
+  end
+
+  def release(before)
+    return unless before
+
+    src = Evilution::Integration::RSpec::StateGuard::Internals.world_ivar(:@sources_by_path)
+    return unless src
+
+    src.delete_if { |k, _v| !before.include?(k) }
+  end
+end

--- a/lib/evilution/integration/rspec/test_file_resolver.rb
+++ b/lib/evilution/integration/rspec/test_file_resolver.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative "../rspec"
+
+class Evilution::Integration::RSpec::TestFileResolver
+  def initialize(test_files:, spec_selector:, related_spec_heuristic:,
+                 related_specs_heuristic_enabled:, fallback_to_full_suite:, warner:)
+    @test_files = test_files
+    @spec_selector = spec_selector
+    @related_spec_heuristic = related_spec_heuristic
+    @related_specs_heuristic_enabled = related_specs_heuristic_enabled
+    @fallback_to_full_suite = fallback_to_full_suite
+    @warner = warner
+  end
+
+  def call(mutation)
+    return @test_files if @test_files
+
+    resolved = Array(@spec_selector.call(mutation.file_path))
+    if resolved.empty?
+      @warner.call(mutation.file_path, fallback_to_full_suite: @fallback_to_full_suite)
+      return @fallback_to_full_suite ? ["spec"] : nil
+    end
+
+    return resolved unless @related_specs_heuristic_enabled
+
+    related = @related_spec_heuristic.call(mutation)
+    (resolved + related).uniq
+  end
+end

--- a/lib/evilution/integration/rspec/unresolved_spec_warner.rb
+++ b/lib/evilution/integration/rspec/unresolved_spec_warner.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "../rspec"
+
+class Evilution::Integration::RSpec::UnresolvedSpecWarner
+  def initialize
+    @warned = Set.new
+  end
+
+  def call(file_path, fallback_to_full_suite:)
+    return if @warned.include?(file_path)
+
+    @warned << file_path
+    action = fallback_to_full_suite ? "running full suite" : "marking mutation unresolved"
+    warn "[evilution] No matching spec found for #{file_path}, #{action}. " \
+         "Use --spec to specify the spec file."
+  end
+end

--- a/spec/evilution/integration/rspec/baseline_runner_spec.rb
+++ b/spec/evilution/integration/rspec/baseline_runner_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/baseline_runner"
+
+RSpec.describe Evilution::Integration::RSpec::BaselineRunner do
+  let(:runner) { described_class.new }
+
+  before do
+    allow(RSpec).to receive(:reset)
+    allow(RSpec::Core::Runner).to receive(:run).and_return(0)
+  end
+
+  it "calls RSpec::Core::Runner.run with --format progress --no-color --order defined args + spec file" do
+    runner.call("spec/foo_spec.rb")
+    expect(RSpec::Core::Runner).to have_received(:run)
+      .with(["--format", "progress", "--no-color", "--order", "defined", "spec/foo_spec.rb"])
+  end
+
+  it "returns true when status is 0" do
+    allow(RSpec::Core::Runner).to receive(:run).and_return(0)
+    expect(runner.call("spec/foo_spec.rb")).to be true
+  end
+
+  it "returns false when status is non-zero" do
+    allow(RSpec::Core::Runner).to receive(:run).and_return(1)
+    expect(runner.call("spec/foo_spec.rb")).to be false
+  end
+
+  it "calls RSpec.reset before running" do
+    runner.call("spec/foo_spec.rb")
+    expect(RSpec).to have_received(:reset)
+  end
+
+  it "prepends spec/ to LOAD_PATH" do
+    runner.call("spec/foo_spec.rb")
+    expect($LOAD_PATH).to include(File.expand_path("spec"))
+  end
+end

--- a/spec/evilution/integration/rspec/crash_detector_lifecycle_spec.rb
+++ b/spec/evilution/integration/rspec/crash_detector_lifecycle_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/crash_detector_lifecycle"
+
+RSpec.describe Evilution::Integration::RSpec::CrashDetectorLifecycle do
+  let(:lifecycle) { described_class.new }
+  let(:fake_detector) { instance_double(Evilution::Integration::CrashDetector, reset: nil) }
+
+  before do
+    allow(Evilution::Integration::CrashDetector).to receive(:new).and_return(fake_detector)
+    allow(RSpec.configuration).to receive(:add_formatter)
+  end
+
+  it "creates and registers a detector on first call" do
+    detector = lifecycle.current
+    expect(detector).to eq(fake_detector)
+    expect(RSpec.configuration).to have_received(:add_formatter).with(fake_detector).once
+  end
+
+  it "reuses the same detector and resets it on subsequent calls" do
+    lifecycle.current
+    lifecycle.current
+    lifecycle.current
+
+    expect(Evilution::Integration::CrashDetector).to have_received(:new).once
+    expect(RSpec.configuration).to have_received(:add_formatter).once
+    expect(fake_detector).to have_received(:reset).twice
+  end
+end

--- a/spec/evilution/integration/rspec/example_filter_applier_spec.rb
+++ b/spec/evilution/integration/rspec/example_filter_applier_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/integration/rspec/example_filter_applier"
+
+RSpec.describe Evilution::Integration::RSpec::ExampleFilterApplier do
+  let(:mutation) { Object.new }
+
+  describe described_class::Identity do
+    it "returns files unchanged" do
+      applier = described_class.new
+      expect(applier.call(mutation, ["spec/a_spec.rb", "spec/b_spec.rb"])).to eq(["spec/a_spec.rb", "spec/b_spec.rb"])
+    end
+  end
+
+  describe described_class::Custom do
+    it "delegates to the wrapped filter" do
+      filter = ->(m, files) { ["filtered_for_#{m.object_id}"] + files }
+      applier = described_class.new(filter)
+      expect(applier.call(mutation, ["a"])).to eq(["filtered_for_#{mutation.object_id}", "a"])
+    end
+
+    it "propagates nil from the filter" do
+      filter = ->(_, _) { nil } # rubocop:disable Style/NilLambda
+      applier = described_class.new(filter)
+      expect(applier.call(mutation, ["a"])).to be_nil
+    end
+  end
+end

--- a/spec/evilution/integration/rspec/framework_loader_spec.rb
+++ b/spec/evilution/integration/rspec/framework_loader_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/integration/rspec/framework_loader"
+
+RSpec.describe Evilution::Integration::RSpec::FrameworkLoader do
+  let(:loader) { described_class.new }
+
+  it "loaded? returns false initially" do
+    expect(loader.loaded?).to be false
+  end
+
+  it "call loads rspec/core, registers crash detector, prepends spec/ to LOAD_PATH, sets loaded?" do
+    allow(loader).to receive(:require).with("rspec/core").and_return(true)
+    allow(Evilution::Integration::CrashDetector).to receive(:register_with_rspec)
+
+    loader.call
+
+    expect(loader).to have_received(:require).with("rspec/core")
+    expect(Evilution::Integration::CrashDetector).to have_received(:register_with_rspec)
+    expect($LOAD_PATH).to include(File.expand_path("spec"))
+    expect(loader.loaded?).to be true
+  end
+
+  it "is idempotent: call twice does not require or register twice" do
+    allow(loader).to receive(:require).with("rspec/core").and_return(true)
+    allow(Evilution::Integration::CrashDetector).to receive(:register_with_rspec)
+
+    loader.call
+    loader.call
+
+    expect(loader).to have_received(:require).with("rspec/core").once
+    expect(Evilution::Integration::CrashDetector).to have_received(:register_with_rspec).once
+  end
+
+  it "translates LoadError into Evilution::Error" do
+    allow(loader).to receive(:require).with("rspec/core").and_raise(LoadError, "no such file")
+
+    expect { loader.call }.to raise_error(Evilution::Error, /rspec-core is required but not available: no such file/)
+  end
+end

--- a/spec/evilution/integration/rspec/result_builder_spec.rb
+++ b/spec/evilution/integration/rspec/result_builder_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/integration/rspec/result_builder"
+
+RSpec.describe Evilution::Integration::RSpec::ResultBuilder do
+  let(:builder) { described_class.new }
+  let(:mutation) { instance_double("Mutation", file_path: "lib/foo.rb") }
+
+  describe "#unresolved" do
+    it "returns the unresolved hash with file_path-aware error and command" do
+      result = builder.unresolved(mutation)
+      expect(result).to eq({
+                             passed: false,
+                             unresolved: true,
+                             error: "no matching spec resolved for lib/foo.rb",
+                             test_command: "rspec (skipped: no spec resolved for lib/foo.rb)"
+                           })
+    end
+  end
+
+  describe "#unresolved_example" do
+    it "returns the unresolved-example hash with file_path-aware error and command" do
+      result = builder.unresolved_example(mutation)
+      expect(result).to eq({
+                             passed: false,
+                             unresolved: true,
+                             error: "no matching example found for lib/foo.rb",
+                             test_command: "rspec (skipped: no matching example for lib/foo.rb)"
+                           })
+    end
+  end
+
+  describe "#from_run" do
+    let(:detector) do
+      instance_double("CrashDetector", only_crashes?: false, unique_crash_classes: [], crash_summary: "")
+    end
+
+    it "returns pass hash when status is zero" do
+      expect(builder.from_run(0, "rspec args", detector))
+        .to eq({ passed: true, test_command: "rspec args" })
+    end
+
+    it "returns crash hash when status nonzero AND only_crashes?, with single error_class" do
+      allow(detector).to receive(:only_crashes?).and_return(true)
+      allow(detector).to receive(:unique_crash_classes).and_return(["RuntimeError"])
+      allow(detector).to receive(:crash_summary).and_return("RuntimeError x1")
+
+      result = builder.from_run(1, "rspec args", detector)
+
+      expect(result).to eq({
+                             passed: false,
+                             test_crashed: true,
+                             error: "test crashes: RuntimeError x1",
+                             error_class: "RuntimeError",
+                             test_command: "rspec args"
+                           })
+    end
+
+    it "returns crash hash WITHOUT error_class when multiple unique_crash_classes" do
+      allow(detector).to receive(:only_crashes?).and_return(true)
+      allow(detector).to receive(:unique_crash_classes).and_return(%w[RuntimeError NoMethodError])
+      allow(detector).to receive(:crash_summary).and_return("multi")
+
+      result = builder.from_run(1, "rspec args", detector)
+
+      expect(result[:test_crashed]).to be true
+      expect(result[:error_class]).to be_nil
+    end
+
+    it "returns plain fail hash when status nonzero AND not only_crashes?" do
+      result = builder.from_run(1, "rspec args", detector)
+      expect(result).to eq({ passed: false, test_command: "rspec args" })
+    end
+  end
+end

--- a/spec/evilution/integration/rspec/state_guard/example_groups_constants_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard/example_groups_constants_spec.rb
@@ -8,15 +8,17 @@ RSpec.describe Evilution::Integration::RSpec::StateGuard::ExampleGroupsConstants
   let(:strategy) { described_class.new }
 
   it "snapshot returns a Set of pre-existing constants on RSpec::ExampleGroups" do
-    RSpec::ExampleGroups.const_set(:HostPreExisting, Class.new) unless RSpec::ExampleGroups.const_defined?(:HostPreExisting)
+    pre_existed = RSpec::ExampleGroups.const_defined?(:HostPreExisting)
+    RSpec::ExampleGroups.const_set(:HostPreExisting, Class.new) unless pre_existed
     snap = strategy.snapshot
     expect(snap).to include(:HostPreExisting)
   ensure
-    RSpec::ExampleGroups.send(:remove_const, :HostPreExisting) if RSpec::ExampleGroups.const_defined?(:HostPreExisting)
+    RSpec::ExampleGroups.send(:remove_const, :HostPreExisting) if !pre_existed && RSpec::ExampleGroups.const_defined?(:HostPreExisting)
   end
 
   it "release removes only constants added after snapshot, leaving pre-existing intact" do
-    RSpec::ExampleGroups.const_set(:HostKeep, Class.new) unless RSpec::ExampleGroups.const_defined?(:HostKeep)
+    host_keep_pre_existed = RSpec::ExampleGroups.const_defined?(:HostKeep)
+    RSpec::ExampleGroups.const_set(:HostKeep, Class.new) unless host_keep_pre_existed
     snap = strategy.snapshot
 
     RSpec::ExampleGroups.const_set(:AddedDuringRun, Class.new)
@@ -26,16 +28,17 @@ RSpec.describe Evilution::Integration::RSpec::StateGuard::ExampleGroupsConstants
     expect(RSpec::ExampleGroups.const_defined?(:HostKeep)).to be true
     expect(RSpec::ExampleGroups.const_defined?(:AddedDuringRun)).to be false
   ensure
-    RSpec::ExampleGroups.send(:remove_const, :HostKeep) if RSpec::ExampleGroups.const_defined?(:HostKeep)
+    RSpec::ExampleGroups.send(:remove_const, :HostKeep) if !host_keep_pre_existed && RSpec::ExampleGroups.const_defined?(:HostKeep)
     RSpec::ExampleGroups.send(:remove_const, :AddedDuringRun) if RSpec::ExampleGroups.const_defined?(:AddedDuringRun)
   end
 
   it "release is a no-op when snapshot is nil" do
-    RSpec::ExampleGroups.const_set(:Untouched, Class.new) unless RSpec::ExampleGroups.const_defined?(:Untouched)
+    untouched_pre_existed = RSpec::ExampleGroups.const_defined?(:Untouched)
+    RSpec::ExampleGroups.const_set(:Untouched, Class.new) unless untouched_pre_existed
     expect { strategy.release(nil) }.not_to raise_error
     expect(RSpec::ExampleGroups.const_defined?(:Untouched)).to be true
   ensure
-    RSpec::ExampleGroups.send(:remove_const, :Untouched) if RSpec::ExampleGroups.const_defined?(:Untouched)
+    RSpec::ExampleGroups.send(:remove_const, :Untouched) if !untouched_pre_existed && RSpec::ExampleGroups.const_defined?(:Untouched)
   end
 
   it "snapshot returns nil if RSpec::ExampleGroups is undefined" do

--- a/spec/evilution/integration/rspec/state_guard/example_groups_constants_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard/example_groups_constants_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/state_guard/example_groups_constants"
+
+RSpec.describe Evilution::Integration::RSpec::StateGuard::ExampleGroupsConstants do
+  let(:strategy) { described_class.new }
+
+  it "snapshot returns a Set of pre-existing constants on RSpec::ExampleGroups" do
+    RSpec::ExampleGroups.const_set(:HostPreExisting, Class.new) unless RSpec::ExampleGroups.const_defined?(:HostPreExisting)
+    snap = strategy.snapshot
+    expect(snap).to include(:HostPreExisting)
+  ensure
+    RSpec::ExampleGroups.send(:remove_const, :HostPreExisting) if RSpec::ExampleGroups.const_defined?(:HostPreExisting)
+  end
+
+  it "release removes only constants added after snapshot, leaving pre-existing intact" do
+    RSpec::ExampleGroups.const_set(:HostKeep, Class.new) unless RSpec::ExampleGroups.const_defined?(:HostKeep)
+    snap = strategy.snapshot
+
+    RSpec::ExampleGroups.const_set(:AddedDuringRun, Class.new)
+
+    strategy.release(snap)
+
+    expect(RSpec::ExampleGroups.const_defined?(:HostKeep)).to be true
+    expect(RSpec::ExampleGroups.const_defined?(:AddedDuringRun)).to be false
+  ensure
+    RSpec::ExampleGroups.send(:remove_const, :HostKeep) if RSpec::ExampleGroups.const_defined?(:HostKeep)
+    RSpec::ExampleGroups.send(:remove_const, :AddedDuringRun) if RSpec::ExampleGroups.const_defined?(:AddedDuringRun)
+  end
+
+  it "release is a no-op when snapshot is nil" do
+    RSpec::ExampleGroups.const_set(:Untouched, Class.new) unless RSpec::ExampleGroups.const_defined?(:Untouched)
+    expect { strategy.release(nil) }.not_to raise_error
+    expect(RSpec::ExampleGroups.const_defined?(:Untouched)).to be true
+  ensure
+    RSpec::ExampleGroups.send(:remove_const, :Untouched) if RSpec::ExampleGroups.const_defined?(:Untouched)
+  end
+
+  it "snapshot returns nil if RSpec::ExampleGroups is undefined" do
+    hide_const("RSpec::ExampleGroups")
+    expect(strategy.snapshot).to be_nil
+  end
+end

--- a/spec/evilution/integration/rspec/state_guard/internals_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard/internals_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/state_guard/internals"
+
+RSpec.describe Evilution::Integration::RSpec::StateGuard::Internals do
+  describe ".world_ivar" do
+    it "returns the value when ivar is defined on RSpec.world" do
+      RSpec.world.instance_variable_set(:@evilution_test_ivar, [:probe])
+      expect(described_class.world_ivar(:@evilution_test_ivar)).to eq([:probe])
+    ensure
+      RSpec.world.remove_instance_variable(:@evilution_test_ivar) if RSpec.world.instance_variable_defined?(:@evilution_test_ivar)
+    end
+
+    it "returns nil when ivar is not defined" do
+      expect(described_class.world_ivar(:@definitely_not_set)).to be_nil
+    end
+  end
+
+  describe ".config_ivar" do
+    it "returns the value when ivar is defined on RSpec.configuration" do
+      RSpec.configuration.instance_variable_set(:@evilution_cfg_test, 42)
+      expect(described_class.config_ivar(:@evilution_cfg_test)).to eq(42)
+    ensure
+      if RSpec.configuration.instance_variable_defined?(:@evilution_cfg_test)
+        RSpec.configuration.remove_instance_variable(:@evilution_cfg_test)
+      end
+    end
+
+    it "returns nil when ivar is not defined" do
+      expect(described_class.config_ivar(:@definitely_not_set)).to be_nil
+    end
+  end
+end

--- a/spec/evilution/integration/rspec/state_guard/object_space_example_groups_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard/object_space_example_groups_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/state_guard/object_space_example_groups"
+
+RSpec.describe Evilution::Integration::RSpec::StateGuard::ObjectSpaceExampleGroups do
+  let(:strategy) { described_class.new }
+
+  it "snapshot returns a Set of object_ids of existing ExampleGroup classes" do
+    snap = strategy.snapshot
+    expect(snap).to be_a(Set)
+    expect(snap).to all(be_a(Integer))
+  end
+
+  it "release prunes constants and ivars from groups created after snapshot" do
+    snap = strategy.snapshot
+
+    new_group = Class.new(RSpec::Core::ExampleGroup) do
+      const_set(:NewConst, :value)
+      instance_variable_set(:@new_ivar, :value)
+    end
+
+    expect(new_group.constants(false)).to include(:NewConst)
+    expect(new_group.instance_variables).to include(:@new_ivar)
+
+    strategy.release(snap)
+
+    expect(new_group.constants(false)).not_to include(:NewConst)
+    expect(new_group.instance_variables).not_to include(:@new_ivar)
+  end
+
+  it "release does not touch groups in the snapshot" do
+    pre_existing = Class.new(RSpec::Core::ExampleGroup) do
+      const_set(:Untouched, :keep)
+      instance_variable_set(:@untouched, :keep)
+    end
+    snap = strategy.snapshot
+    expect(snap).to include(pre_existing.object_id)
+
+    strategy.release(snap)
+
+    expect(pre_existing.constants(false)).to include(:Untouched)
+    expect(pre_existing.instance_variables).to include(:@untouched)
+  end
+
+  it "release is a no-op when snapshot is nil" do
+    expect { strategy.release(nil) }.not_to raise_error
+  end
+end

--- a/spec/evilution/integration/rspec/state_guard/reporter_arrays_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard/reporter_arrays_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/state_guard/reporter_arrays"
+
+RSpec.describe Evilution::Integration::RSpec::StateGuard::ReporterArrays do
+  let(:strategy) { described_class.new }
+  let(:fake_reporter) do
+    Class.new do
+      def initialize
+        @examples = []
+        @failed_examples = []
+        @pending_examples = []
+      end
+
+      attr_reader :examples, :failed_examples, :pending_examples
+    end.new
+  end
+
+  before do
+    @cfg_backup = if RSpec.configuration.instance_variable_defined?(:@reporter)
+                    RSpec.configuration.instance_variable_get(:@reporter)
+                  else
+                    :__missing__
+                  end
+    RSpec.configuration.instance_variable_set(:@reporter, fake_reporter)
+  end
+
+  after do
+    if @cfg_backup == :__missing__
+      RSpec.configuration.remove_instance_variable(:@reporter) if RSpec.configuration.instance_variable_defined?(:@reporter)
+    else
+      RSpec.configuration.instance_variable_set(:@reporter, @cfg_backup)
+    end
+  end
+
+  it "snapshot returns lengths of the three reporter arrays" do
+    fake_reporter.examples.push(:e1, :e2)
+    fake_reporter.failed_examples.push(:f1)
+    snap = strategy.snapshot
+    expect(snap).to eq({ :@examples => 2, :@failed_examples => 1, :@pending_examples => 0 })
+  end
+
+  it "release slices arrays back to snapshot lengths" do
+    fake_reporter.examples.push(:pre)
+    snap = strategy.snapshot
+    fake_reporter.examples.push(:added_a, :added_b)
+
+    strategy.release(snap)
+
+    expect(fake_reporter.examples).to eq([:pre])
+  end
+
+  it "release is a no-op when snapshot is nil" do
+    fake_reporter.examples.push(:a, :b)
+    expect { strategy.release(nil) }.not_to raise_error
+    expect(fake_reporter.examples).to eq(%i[a b])
+  end
+
+  it "snapshot returns nil when reporter ivar is missing" do
+    RSpec.configuration.remove_instance_variable(:@reporter) if RSpec.configuration.instance_variable_defined?(:@reporter)
+    expect(strategy.snapshot).to be_nil
+  end
+
+  it "snapshot omits ivars that are not defined on the reporter" do
+    partial_reporter = Class.new do
+      def initialize
+        @examples = [:e1]
+      end
+      attr_reader :examples
+    end.new
+    RSpec.configuration.instance_variable_set(:@reporter, partial_reporter)
+
+    snap = strategy.snapshot
+
+    expect(snap).to eq({ :@examples => 1 })
+  end
+
+  it "snapshot skips ivars whose value is not an Array" do
+    weird_reporter = Class.new do
+      def initialize
+        @examples = []
+        @failed_examples = "not an array"
+        @pending_examples = nil
+      end
+      attr_reader :examples, :failed_examples, :pending_examples
+    end.new
+    RSpec.configuration.instance_variable_set(:@reporter, weird_reporter)
+
+    snap = strategy.snapshot
+
+    expect(snap).to eq({ :@examples => 0 })
+  end
+
+  it "release is a no-op when reporter ivar is missing on RSpec.configuration" do
+    fake_reporter.examples.push(:pre)
+    snap = strategy.snapshot
+    RSpec.configuration.remove_instance_variable(:@reporter) if RSpec.configuration.instance_variable_defined?(:@reporter)
+
+    expect { strategy.release(snap) }.not_to raise_error
+  end
+end

--- a/spec/evilution/integration/rspec/state_guard/world_example_groups_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard/world_example_groups_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/state_guard/world_example_groups"
+
+RSpec.describe Evilution::Integration::RSpec::StateGuard::WorldExampleGroups do
+  let(:strategy) { described_class.new }
+
+  before do
+    @world_groups_backup = RSpec.world.instance_variable_get(:@example_groups).dup
+  end
+
+  after do
+    RSpec.world.instance_variable_set(:@example_groups, @world_groups_backup)
+  end
+
+  it "snapshot returns a frozen dup of the example_groups array" do
+    RSpec.world.instance_variable_set(:@example_groups, %i[host_a host_b])
+    snap = strategy.snapshot
+    expect(snap).to eq(%i[host_a host_b])
+    expect(snap).to be_frozen
+  end
+
+  it "snapshot returns nil when @example_groups ivar is missing" do
+    RSpec.world.remove_instance_variable(:@example_groups) if RSpec.world.instance_variable_defined?(:@example_groups)
+    expect(strategy.snapshot).to be_nil
+  ensure
+    RSpec.world.instance_variable_set(:@example_groups, [])
+  end
+
+  it "release removes only entries added after snapshot, leaving pre-existing ones intact" do
+    RSpec.world.instance_variable_set(:@example_groups, %i[host_a host_b])
+    snap = strategy.snapshot
+
+    groups = RSpec.world.instance_variable_get(:@example_groups)
+    groups.push(:added_x, :added_y)
+
+    strategy.release(snap)
+
+    expect(RSpec.world.instance_variable_get(:@example_groups)).to eq(%i[host_a host_b])
+  end
+
+  it "release is a no-op when snapshot is nil" do
+    RSpec.world.instance_variable_set(:@example_groups, %i[a b c])
+    expect { strategy.release(nil) }.not_to raise_error
+    expect(RSpec.world.instance_variable_get(:@example_groups)).to eq(%i[a b c])
+  end
+end

--- a/spec/evilution/integration/rspec/state_guard/world_filtered_examples_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard/world_filtered_examples_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/state_guard/world_filtered_examples"
+
+RSpec.describe Evilution::Integration::RSpec::StateGuard::WorldFilteredExamples do
+  let(:strategy) { described_class.new }
+
+  before do
+    @backup = if RSpec.world.instance_variable_defined?(:@filtered_examples)
+                RSpec.world.instance_variable_get(:@filtered_examples).dup
+              else
+                :__missing__
+              end
+  end
+
+  after do
+    if @backup == :__missing__
+      RSpec.world.remove_instance_variable(:@filtered_examples) if RSpec.world.instance_variable_defined?(:@filtered_examples)
+    else
+      RSpec.world.instance_variable_set(:@filtered_examples, @backup)
+    end
+  end
+
+  it "snapshot returns a Set of object_ids of pre-existing keys" do
+    a = Object.new
+    b = Object.new
+    RSpec.world.instance_variable_set(:@filtered_examples, { a => 1, b => 2 })
+    snap = strategy.snapshot
+    expect(snap).to eq(Set.new([a.object_id, b.object_id]))
+  end
+
+  it "snapshot returns nil when ivar is missing" do
+    RSpec.world.remove_instance_variable(:@filtered_examples) if RSpec.world.instance_variable_defined?(:@filtered_examples)
+    expect(strategy.snapshot).to be_nil
+  end
+
+  it "release removes only keys added after snapshot" do
+    pre = Object.new
+    RSpec.world.instance_variable_set(:@filtered_examples, { pre => 1 })
+    snap = strategy.snapshot
+
+    new_key = Object.new
+    RSpec.world.instance_variable_get(:@filtered_examples)[new_key] = 2
+
+    strategy.release(snap)
+
+    fe = RSpec.world.instance_variable_get(:@filtered_examples)
+    expect(fe.keys).to eq([pre])
+  end
+end

--- a/spec/evilution/integration/rspec/state_guard/world_sources_by_path_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard/world_sources_by_path_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec/state_guard/world_sources_by_path"
+
+RSpec.describe Evilution::Integration::RSpec::StateGuard::WorldSourcesByPath do
+  let(:strategy) { described_class.new }
+
+  before do
+    @backup = if RSpec.world.instance_variable_defined?(:@sources_by_path)
+                RSpec.world.instance_variable_get(:@sources_by_path).dup
+              else
+                :__missing__
+              end
+  end
+
+  after do
+    if @backup == :__missing__
+      RSpec.world.remove_instance_variable(:@sources_by_path) if RSpec.world.instance_variable_defined?(:@sources_by_path)
+    else
+      RSpec.world.instance_variable_set(:@sources_by_path, @backup)
+    end
+  end
+
+  it "snapshot returns a Set of existing keys" do
+    RSpec.world.instance_variable_set(:@sources_by_path, { "host/a.rb" => :a, "host/b.rb" => :b })
+    snap = strategy.snapshot
+    expect(snap).to be_a(Set)
+    expect(snap).to eq(Set.new(["host/a.rb", "host/b.rb"]))
+  end
+
+  it "snapshot returns nil when ivar is missing" do
+    RSpec.world.remove_instance_variable(:@sources_by_path) if RSpec.world.instance_variable_defined?(:@sources_by_path)
+    expect(strategy.snapshot).to be_nil
+  end
+
+  it "release removes only keys added after snapshot, leaving pre-existing intact" do
+    RSpec.world.instance_variable_set(:@sources_by_path, { "host/a.rb" => :a })
+    snap = strategy.snapshot
+
+    src = RSpec.world.instance_variable_get(:@sources_by_path)
+    src["added.rb"] = :new
+
+    strategy.release(snap)
+
+    expect(RSpec.world.instance_variable_get(:@sources_by_path).keys).to eq(["host/a.rb"])
+  end
+
+  it "release is a no-op when snapshot is nil" do
+    RSpec.world.instance_variable_set(:@sources_by_path, { "x" => 1 })
+    expect { strategy.release(nil) }.not_to raise_error
+    expect(RSpec.world.instance_variable_get(:@sources_by_path).keys).to eq(["x"])
+  end
+end

--- a/spec/evilution/integration/rspec/state_guard_spec.rb
+++ b/spec/evilution/integration/rspec/state_guard_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/integration/rspec/state_guard"
+
+RSpec.describe Evilution::Integration::RSpec::StateGuard do
+  let(:fake_strategy_class) do
+    Class.new do
+      attr_reader :snapshots, :releases
+
+      def initialize(label)
+        @label = label
+        @snapshots = 0
+        @releases = []
+      end
+
+      def snapshot
+        @snapshots += 1
+        "#{@label}_token"
+      end
+
+      def release(token)
+        @releases << token
+      end
+    end
+  end
+
+  it "snapshot calls each strategy in order, returning [strategy, token] pairs" do
+    a = fake_strategy_class.new("a")
+    b = fake_strategy_class.new("b")
+    guard = described_class.new(strategies: [a, b])
+
+    token = guard.snapshot
+
+    expect(token).to eq([[a, "a_token"], [b, "b_token"]])
+    expect(a.snapshots).to eq(1)
+    expect(b.snapshots).to eq(1)
+  end
+
+  it "release fans out in REVERSE order" do
+    order = []
+    a = fake_strategy_class.new("a").tap do |s|
+      s.define_singleton_method(:release) { |t| order << "a:#{t}" }
+    end
+    b = fake_strategy_class.new("b").tap do |s|
+      s.define_singleton_method(:release) { |t| order << "b:#{t}" }
+    end
+    guard = described_class.new(strategies: [a, b])
+
+    token = guard.snapshot
+    guard.release(token)
+
+    expect(order).to eq(["b:b_token", "a:a_token"])
+  end
+
+  it "release continues if one strategy raises" do
+    raising = fake_strategy_class.new("r").tap do |s|
+      s.define_singleton_method(:release) { |_| raise StandardError, "boom" }
+    end
+    succeeding = fake_strategy_class.new("s")
+    guard = described_class.new(strategies: [raising, succeeding])
+
+    token = guard.snapshot
+    expect { guard.release(token) }.to output(/state release failed for/).to_stderr
+    expect(succeeding.releases).to eq(["s_token"])
+  end
+
+  it "uses DEFAULT_STRATEGIES when none provided (smoke test)" do
+    expect { described_class.new }.not_to raise_error
+    expect(described_class::DEFAULT_STRATEGIES).to all(respond_to(:snapshot, :release))
+  end
+end

--- a/spec/evilution/integration/rspec/test_file_resolver_spec.rb
+++ b/spec/evilution/integration/rspec/test_file_resolver_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/integration/rspec/test_file_resolver"
+require "evilution/integration/rspec/unresolved_spec_warner"
+
+RSpec.describe Evilution::Integration::RSpec::TestFileResolver do
+  let(:mutation) { instance_double("Mutation", file_path: "lib/foo.rb") }
+  let(:warner) { instance_double(Evilution::Integration::RSpec::UnresolvedSpecWarner, call: nil) }
+  let(:related_heuristic) { instance_double("RelatedSpecHeuristic", call: []) }
+
+  def build(spec_selector_result:, **overrides)
+    spec_selector = ->(_path) { spec_selector_result }
+    described_class.new(
+      test_files: nil,
+      spec_selector: spec_selector,
+      related_spec_heuristic: related_heuristic,
+      related_specs_heuristic_enabled: false,
+      fallback_to_full_suite: false,
+      warner: warner,
+      **overrides
+    )
+  end
+
+  it "returns test_files override and ignores spec_selector when test_files: is set" do
+    resolver = build(spec_selector_result: ["wrong"], test_files: ["forced.rb"])
+    expect(resolver.call(mutation)).to eq(["forced.rb"])
+  end
+
+  it "returns spec_selector results when non-empty" do
+    resolver = build(spec_selector_result: ["spec/foo_spec.rb"])
+    expect(resolver.call(mutation)).to eq(["spec/foo_spec.rb"])
+  end
+
+  it "returns ['spec'] when selector empty AND fallback_to_full_suite is true" do
+    resolver = build(spec_selector_result: [], fallback_to_full_suite: true)
+    expect(resolver.call(mutation)).to eq(["spec"])
+    expect(warner).to have_received(:call).with("lib/foo.rb", fallback_to_full_suite: true)
+  end
+
+  it "returns nil when selector empty AND fallback_to_full_suite is false" do
+    resolver = build(spec_selector_result: [], fallback_to_full_suite: false)
+    expect(resolver.call(mutation)).to be_nil
+    expect(warner).to have_received(:call).with("lib/foo.rb", fallback_to_full_suite: false)
+  end
+
+  it "unions related_spec_heuristic results with selector results when heuristic enabled, deduped" do
+    allow(related_heuristic).to receive(:call).with(mutation).and_return(["spec/related_spec.rb", "spec/foo_spec.rb"])
+    resolver = build(spec_selector_result: ["spec/foo_spec.rb"], related_specs_heuristic_enabled: true)
+    expect(resolver.call(mutation)).to eq(["spec/foo_spec.rb", "spec/related_spec.rb"])
+  end
+
+  it "skips related_spec_heuristic when not enabled" do
+    resolver = build(spec_selector_result: ["spec/foo_spec.rb"], related_specs_heuristic_enabled: false)
+    resolver.call(mutation)
+    expect(related_heuristic).not_to have_received(:call)
+  end
+end

--- a/spec/evilution/integration/rspec/unresolved_spec_warner_spec.rb
+++ b/spec/evilution/integration/rspec/unresolved_spec_warner_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/integration/rspec/unresolved_spec_warner"
+
+RSpec.describe Evilution::Integration::RSpec::UnresolvedSpecWarner do
+  let(:warner) { described_class.new }
+
+  it "warns on first call for a file_path" do
+    expect { warner.call("lib/foo.rb", fallback_to_full_suite: false) }
+      .to output(%r{No matching spec found for lib/foo\.rb, marking mutation unresolved}).to_stderr
+  end
+
+  it "is silent on subsequent calls for the same file_path" do
+    warner.call("lib/foo.rb", fallback_to_full_suite: false)
+    expect { warner.call("lib/foo.rb", fallback_to_full_suite: false) }.not_to output.to_stderr
+  end
+
+  it "warns again for a different file_path" do
+    warner.call("lib/foo.rb", fallback_to_full_suite: false)
+    expect { warner.call("lib/bar.rb", fallback_to_full_suite: false) }.to output(%r{lib/bar\.rb}).to_stderr
+  end
+
+  it "uses 'running full suite' message when fallback flag is true" do
+    expect { warner.call("lib/foo.rb", fallback_to_full_suite: true) }
+      .to output(/running full suite/).to_stderr
+  end
+
+  it "uses 'marking mutation unresolved' message when fallback flag is false" do
+    expect { warner.call("lib/foo.rb", fallback_to_full_suite: false) }
+      .to output(/marking mutation unresolved/).to_stderr
+  end
+end

--- a/spec/evilution/integration/rspec_host_isolation_spec.rb
+++ b/spec/evilution/integration/rspec_host_isolation_spec.rb
@@ -60,7 +60,8 @@ RSpec.describe "Evilution::Integration::RSpec host isolation" do
   end
 
   it "preserves pre-existing RSpec::ExampleGroups constants across a run" do
-    RSpec::ExampleGroups.const_set(:HostPre, Class.new) unless RSpec::ExampleGroups.const_defined?(:HostPre)
+    host_pre_was_preexisting = RSpec::ExampleGroups.const_defined?(:HostPre)
+    RSpec::ExampleGroups.const_set(:HostPre, Class.new) unless host_pre_was_preexisting
 
     integration = Evilution::Integration::RSpec.new(test_files: ["spec/nonexistent_spec.rb"])
     allow(RSpec::Core::Runner).to receive(:run) do |_, _, _|
@@ -75,7 +76,7 @@ RSpec.describe "Evilution::Integration::RSpec host isolation" do
     expect(RSpec::ExampleGroups.const_defined?(:HostPre)).to be true
     expect(RSpec::ExampleGroups.const_defined?(:AddedDuringRun)).to be false
   ensure
-    RSpec::ExampleGroups.send(:remove_const, :HostPre) if RSpec::ExampleGroups.const_defined?(:HostPre)
+    RSpec::ExampleGroups.send(:remove_const, :HostPre) if !host_pre_was_preexisting && RSpec::ExampleGroups.const_defined?(:HostPre)
     RSpec::ExampleGroups.send(:remove_const, :AddedDuringRun) if RSpec::ExampleGroups.const_defined?(:AddedDuringRun)
   end
 end

--- a/spec/evilution/integration/rspec_host_isolation_spec.rb
+++ b/spec/evilution/integration/rspec_host_isolation_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rspec/core"
+require "evilution/integration/rspec"
+
+RSpec.describe "Evilution::Integration::RSpec host isolation" do
+  before do
+    allow(RSpec.configuration).to receive(:add_formatter)
+  end
+
+  it "preserves pre-existing RSpec.world.@example_groups across a run" do
+    # Pre-populate world with synthetic host entries
+    backup = RSpec.world.instance_variable_get(:@example_groups).dup
+    RSpec.world.instance_variable_set(:@example_groups, %i[host_pre_a host_pre_b])
+
+    # Drive a run with no real spec to execute by stubbing Runner.run
+    integration = Evilution::Integration::RSpec.new(test_files: ["spec/nonexistent_spec.rb"])
+    allow(RSpec::Core::Runner).to receive(:run) do |_, _, _|
+      # Simulate RSpec adding to the world during the run
+      RSpec.world.instance_variable_get(:@example_groups).push(:added_during_run)
+      0
+    end
+    allow(integration).to receive(:reset_examples)
+
+    mutation = instance_double("Mutation", file_path: "lib/foo.rb")
+    integration.send(:run_tests, mutation)
+
+    # Pre-existing entries survive; entries added during run are removed.
+    final_groups = RSpec.world.instance_variable_get(:@example_groups)
+    expect(final_groups).to include(:host_pre_a, :host_pre_b)
+    expect(final_groups).not_to include(:added_during_run)
+  ensure
+    RSpec.world.instance_variable_set(:@example_groups, backup) if backup
+  end
+
+  it "preserves pre-existing RSpec.world.@sources_by_path keys across a run" do
+    src_backup = (RSpec.world.instance_variable_get(:@sources_by_path).dup if RSpec.world.instance_variable_defined?(:@sources_by_path))
+    RSpec.world.instance_variable_set(:@sources_by_path, { "host_existing.rb" => :data })
+
+    integration = Evilution::Integration::RSpec.new(test_files: ["spec/nonexistent_spec.rb"])
+    allow(RSpec::Core::Runner).to receive(:run) do |_, _, _|
+      RSpec.world.instance_variable_get(:@sources_by_path)["added_during_run.rb"] = :added
+      0
+    end
+    allow(integration).to receive(:reset_examples)
+
+    mutation = instance_double("Mutation", file_path: "lib/foo.rb")
+    integration.send(:run_tests, mutation)
+
+    keys = RSpec.world.instance_variable_get(:@sources_by_path).keys
+    expect(keys).to include("host_existing.rb")
+    expect(keys).not_to include("added_during_run.rb")
+  ensure
+    if src_backup
+      RSpec.world.instance_variable_set(:@sources_by_path, src_backup)
+    elsif RSpec.world.instance_variable_defined?(:@sources_by_path)
+      RSpec.world.remove_instance_variable(:@sources_by_path)
+    end
+  end
+
+  it "preserves pre-existing RSpec::ExampleGroups constants across a run" do
+    RSpec::ExampleGroups.const_set(:HostPre, Class.new) unless RSpec::ExampleGroups.const_defined?(:HostPre)
+
+    integration = Evilution::Integration::RSpec.new(test_files: ["spec/nonexistent_spec.rb"])
+    allow(RSpec::Core::Runner).to receive(:run) do |_, _, _|
+      RSpec::ExampleGroups.const_set(:AddedDuringRun, Class.new)
+      0
+    end
+    allow(integration).to receive(:reset_examples)
+
+    mutation = instance_double("Mutation", file_path: "lib/foo.rb")
+    integration.send(:run_tests, mutation)
+
+    expect(RSpec::ExampleGroups.const_defined?(:HostPre)).to be true
+    expect(RSpec::ExampleGroups.const_defined?(:AddedDuringRun)).to be false
+  ensure
+    RSpec::ExampleGroups.send(:remove_const, :HostPre) if RSpec::ExampleGroups.const_defined?(:HostPre)
+    RSpec::ExampleGroups.send(:remove_const, :AddedDuringRun) if RSpec::ExampleGroups.const_defined?(:AddedDuringRun)
+  end
+end

--- a/spec/evilution/integration/rspec_spec.rb
+++ b/spec/evilution/integration/rspec_spec.rb
@@ -153,30 +153,44 @@ RSpec.describe Evilution::Integration::RSpec do
       end
     end
 
-    it "removes ExampleGroup constants after each run" do
-      allow(RSpec::Core::Runner).to receive(:run).and_return(0)
-      allow(RSpec::ExampleGroups).to receive(:remove_all_constants)
+    # Snapshot-aware ExampleGroups constant removal (only constants added
+    # during the run are removed, pre-existing host constants survive) is
+    # covered end-to-end in spec/evilution/integration/rspec_host_isolation_spec.rb
+    # and at the unit level in
+    # spec/evilution/integration/rspec/state_guard/example_groups_constants_spec.rb.
+    # The previous test here asserted the old blanket-clear behavior
+    # (RSpec::ExampleGroups.remove_all_constants) which was the bug fixed by
+    # the StateGuard refactor and is intentionally no longer used.
 
-      integration.call(mutation)
-
-      expect(RSpec::ExampleGroups).to have_received(:remove_all_constants).at_least(:once)
-    end
-
-    it "raises Evilution::Error when rspec-core is not available" do
-      integration_no_rspec = described_class.new(test_files: ["spec/some_spec.rb"])
-      integration_no_rspec.instance_variable_set(:@rspec_loaded, false)
-      allow(integration_no_rspec).to receive(:require).with("rspec/core").and_raise(LoadError, "cannot load such file -- rspec/core")
+    it "propagates Evilution::Error raised by the framework loader" do
+      failing_loader = instance_double(
+        Evilution::Integration::RSpec::FrameworkLoader,
+        loaded?: false
+      )
+      allow(failing_loader).to receive(:call).and_raise(
+        Evilution::Error, "rspec-core is required but not available: cannot load such file -- rspec/core"
+      )
+      integration_no_rspec = described_class.new(
+        test_files: ["spec/some_spec.rb"],
+        framework_loader: failing_loader
+      )
 
       expect { integration_no_rspec.call(mutation) }.to raise_error(Evilution::Error, /rspec-core is required/)
     end
 
-    it "does not modify original file when ensure_rspec_loaded raises" do
-      integration_no_rspec = described_class.new(test_files: ["spec/some_spec.rb"])
-      integration_no_rspec.instance_variable_set(:@rspec_loaded, false)
-      allow(integration_no_rspec).to receive(:require).with("rspec/core").and_raise(LoadError, "nope")
+    it "does not modify original file when framework loader raises" do
+      failing_loader = instance_double(
+        Evilution::Integration::RSpec::FrameworkLoader,
+        loaded?: false
+      )
+      allow(failing_loader).to receive(:call).and_raise(Evilution::Error, "nope")
+      integration_no_rspec = described_class.new(
+        test_files: ["spec/some_spec.rb"],
+        framework_loader: failing_loader
+      )
 
       expect { integration_no_rspec.call(mutation) }.to raise_error(Evilution::Error)
-      # Original file should never be touched
+      # Original file should never be touched (loader runs before mutation_applier)
       expect(File.read(source_file.path)).to eq(original_source)
     end
   end
@@ -439,40 +453,57 @@ RSpec.describe Evilution::Integration::RSpec do
   end
 
   describe "setup_integration hooks" do
+    # A fake framework loader that records when #call fires so tests can
+    # observe ordering between setup_integration hooks and the actual load.
+    let(:recording_loader_class) do
+      Class.new do
+        attr_reader :events
+
+        def initialize(events)
+          @events = events
+          @loaded = false
+        end
+
+        def loaded?
+          @loaded
+        end
+
+        def call
+          @events << :load
+          @loaded = true
+        end
+      end
+    end
+
     it "fires setup_integration_pre before loading rspec" do
       hooks = Evilution::Hooks::Registry.new
       events = []
       hooks.register(:setup_integration_pre) { events << :setup_pre }
-      hooked_integration = described_class.new(test_files: ["spec/some_spec.rb"], hooks: hooks)
-      hooked_integration.instance_variable_set(:@rspec_loaded, false)
-
-      allow(hooked_integration).to receive(:require).with("rspec/core") do
-        events << :require
-        # Simulate successful load
-      end
+      loader = recording_loader_class.new(events)
+      hooked_integration = described_class.new(
+        test_files: ["spec/some_spec.rb"], hooks: hooks, framework_loader: loader
+      )
       allow(RSpec::Core::Runner).to receive(:run).and_return(0)
 
       hooked_integration.call(mutation)
 
       expect(events[0]).to eq(:setup_pre)
-      expect(events[1]).to eq(:require)
+      expect(events[1]).to eq(:load)
     end
 
     it "fires setup_integration_post after loading rspec" do
       hooks = Evilution::Hooks::Registry.new
       events = []
       hooks.register(:setup_integration_post) { events << :setup_post }
-      hooked_integration = described_class.new(test_files: ["spec/some_spec.rb"], hooks: hooks)
-      hooked_integration.instance_variable_set(:@rspec_loaded, false)
-
-      allow(hooked_integration).to receive(:require).with("rspec/core") do
-        events << :require
-      end
+      loader = recording_loader_class.new(events)
+      hooked_integration = described_class.new(
+        test_files: ["spec/some_spec.rb"], hooks: hooks, framework_loader: loader
+      )
       allow(RSpec::Core::Runner).to receive(:run).and_return(0)
 
       hooked_integration.call(mutation)
 
-      expect(events[0]).to eq(:require)
+      expect(events[0]).to eq(:load)
       expect(events[1]).to eq(:setup_post)
     end
 
@@ -481,15 +512,15 @@ RSpec.describe Evilution::Integration::RSpec do
       events = []
       hooks.register(:setup_integration_pre) { events << :setup_pre }
       hooks.register(:setup_integration_post) { events << :setup_post }
-      hooked_integration = described_class.new(test_files: ["spec/some_spec.rb"], hooks: hooks)
-      hooked_integration.instance_variable_set(:@rspec_loaded, false)
-
-      allow(hooked_integration).to receive(:require).with("rspec/core")
+      loader = recording_loader_class.new(events)
+      hooked_integration = described_class.new(
+        test_files: ["spec/some_spec.rb"], hooks: hooks, framework_loader: loader
+      )
       allow(RSpec::Core::Runner).to receive(:run).and_return(0)
 
       hooked_integration.call(mutation)
 
-      expect(events).to eq(%i[setup_pre setup_post])
+      expect(events).to eq(%i[setup_pre load setup_post])
     end
 
     it "provides integration type in hook payload" do
@@ -518,9 +549,10 @@ RSpec.describe Evilution::Integration::RSpec do
     end
 
     it "works without hooks (backwards compatible)" do
-      no_hooks_integration = described_class.new(test_files: ["spec/some_spec.rb"])
-      no_hooks_integration.instance_variable_set(:@rspec_loaded, false)
-      allow(no_hooks_integration).to receive(:require).with("rspec/core")
+      loader = recording_loader_class.new([])
+      no_hooks_integration = described_class.new(
+        test_files: ["spec/some_spec.rb"], framework_loader: loader
+      )
       allow(RSpec::Core::Runner).to receive(:run).and_return(0)
 
       result = no_hooks_integration.call(mutation)

--- a/spec/evilution/mcp/mutate_tool_spec.rb
+++ b/spec/evilution/mcp/mutate_tool_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe Evilution::MCP::MutateTool do
       errors: 0,
       neutral: 0,
       equivalent: 0,
+      unparseable: 0,
+      unparseable_results: [],
       score: 1.0,
       duration: 0.5,
       killtime: 0.123,
@@ -371,7 +373,9 @@ RSpec.describe Evilution::MCP::MutateTool do
           disabled_mutations: [],
           coverage_gaps: [],
           unresolved: 0,
-          unresolved_results: []
+          unresolved_results: [],
+          unparseable: 0,
+          unparseable_results: []
         )
         allow(runner).to receive(:call).and_return(timed_out_summary)
 
@@ -425,7 +429,9 @@ RSpec.describe Evilution::MCP::MutateTool do
           disabled_mutations: [],
           coverage_gaps: [],
           unresolved: 0,
-          unresolved_results: []
+          unresolved_results: [],
+          unparseable: 0,
+          unparseable_results: []
         )
         allow(runner).to receive(:call).and_return(error_summary)
 
@@ -479,7 +485,9 @@ RSpec.describe Evilution::MCP::MutateTool do
           disabled_mutations: [],
           coverage_gaps: [],
           unresolved: 0,
-          unresolved_results: []
+          unresolved_results: [],
+          unparseable: 0,
+          unparseable_results: []
         )
         allow(runner).to receive(:call).and_return(neutral_summary)
 
@@ -545,7 +553,9 @@ RSpec.describe Evilution::MCP::MutateTool do
           disabled_mutations: [],
           coverage_gaps: [],
           unresolved: 0,
-          unresolved_results: []
+          unresolved_results: [],
+          unparseable: 0,
+          unparseable_results: []
         )
         allow(runner).to receive(:call).and_return(survived_summary)
 
@@ -615,7 +625,9 @@ RSpec.describe Evilution::MCP::MutateTool do
             disabled_mutations: [],
             coverage_gaps: [],
             unresolved: 0,
-            unresolved_results: []
+            unresolved_results: [],
+            unparseable: 0,
+            unparseable_results: []
           )
         end
 
@@ -847,7 +859,9 @@ RSpec.describe Evilution::MCP::MutateTool do
           disabled_mutations: [],
           coverage_gaps: [],
           unresolved: 0,
-          unresolved_results: []
+          unresolved_results: [],
+          unparseable: 0,
+          unparseable_results: []
         )
         allow(runner).to receive(:call).and_return(equivalent_summary)
 
@@ -924,7 +938,9 @@ RSpec.describe Evilution::MCP::MutateTool do
           disabled_mutations: [],
           coverage_gaps: [],
           unresolved: 0,
-          unresolved_results: []
+          unresolved_results: [],
+          unparseable: 0,
+          unparseable_results: []
         )
       end
 

--- a/spec/evilution/reporter/memory_stats_spec.rb
+++ b/spec/evilution/reporter/memory_stats_spec.rb
@@ -7,13 +7,17 @@ require "evilution/result/mutation_result"
 require "evilution/result/summary"
 
 RSpec.describe "Reporter memory stats" do
+  let(:subject_obj) { double("Subject", name: "User#valid?") }
+
   let(:mutation) do
     double("Mutation",
            operator_name: "comparison_replacement",
            file_path: "lib/user.rb",
            line: 9,
            diff: "- x >= 10\n+ x > 10",
-           unified_diff: nil)
+           unified_diff: nil,
+           subject: subject_obj,
+           unparseable?: false)
   end
 
   let(:result_with_rss) do

--- a/spec/evilution/runner/baseline_runner_spec.rb
+++ b/spec/evilution/runner/baseline_runner_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Evilution::Runner::BaselineRunner do
       runner = described_class.new(config(baseline: true, integration: :rspec, timeout: 7))
       baseline = instance_double(Evilution::Baseline, call: :ok)
       expect(Evilution::Baseline).to receive(:new)
-        .with(hash_including(timeout: 7, runner: instance_of(Proc)))
+        .with(hash_including(timeout: 7, runner: instance_of(Evilution::Integration::RSpec::BaselineRunner)))
         .and_return(baseline)
       expect(runner.call([:subject])).to eq(:ok)
     end

--- a/spec/evilution/runner_isolation_spec.rb
+++ b/spec/evilution/runner_isolation_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Evilution::Runner, "isolation resolution" do
   end
 
   def resolved_isolator_class(runner)
-    runner.send(:build_isolator).class
+    runner.send(:isolator).class
   end
 
   describe "with isolation: :auto" do
@@ -63,7 +63,7 @@ RSpec.describe Evilution::Runner, "isolation resolution" do
       config = build_config(target_files: [])
       runner = described_class.new(config: config)
       resolved = [File.join(@tmp, "app", "models", "user.rb")]
-      allow(runner).to receive(:resolve_target_files).and_return(resolved)
+      allow(runner.send(:subject_pipeline)).to receive(:target_files).and_return(resolved)
       expect(resolved_isolator_class(runner)).to eq(Evilution::Isolation::Fork)
     end
   end
@@ -118,7 +118,7 @@ RSpec.describe Evilution::Runner, "isolation resolution" do
         quiet: true
       )
       runner = described_class.new(config: config)
-      expect { runner.send(:build_isolator) }.not_to output.to_stderr
+      expect { runner.send(:isolator) }.not_to output.to_stderr
     end
 
     it "does not warn twice for repeated calls in the same run" do
@@ -132,21 +132,21 @@ RSpec.describe Evilution::Runner, "isolation resolution" do
       orig = $stderr
       $stderr = captured
       runner = described_class.new(config: config)
-      runner.send(:build_isolator) # first warn
-      runner.send(:build_isolator) # should not warn again
+      runner.send(:isolator) # first warn
+      runner.send(:isolator) # should not warn again
       $stderr = orig
       expect(captured.string.scan("handle_interrupt").length).to eq(1)
     end
   end
 
   describe "parallel mode" do
-    it "uses build_isolator for worker isolation, not hardcoded InProcess" do
+    it "uses isolator for worker isolation, not hardcoded InProcess" do
       write_plain_target
       config = build_config(isolation: :fork, jobs: 2)
       runner = described_class.new(config: config)
 
-      expect(runner).to receive(:build_isolator).at_least(:once).and_call_original
-      runner.send(:run_mutations_parallel, [])
+      expect(runner).to receive(:isolator).at_least(:once).and_call_original
+      runner.send(:mutation_executor).send(:run_parallel, [], nil)
     end
   end
 end

--- a/spec/evilution/runner_memory_spec.rb
+++ b/spec/evilution/runner_memory_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe Evilution::Runner, "memory instrumentation" do
       line: 3,
       column: 4,
       diff: "- a >= b\n+ a > b",
-      strip_sources!: nil
+      strip_sources!: nil,
+      unparseable?: false,
+      unified_diff: nil
     )
   end
 

--- a/spec/evilution/runner_preload_spec.rb
+++ b/spec/evilution/runner_preload_spec.rb
@@ -158,7 +158,8 @@ RSpec.describe Evilution::Runner, "preload" do
       runner = described_class.new(config: build_config)
 
       load_order = []
-      allow(runner).to receive(:require).and_wrap_original do |original, path|
+      resolver = runner.send(:isolation_resolver)
+      allow(resolver).to receive(:require).and_wrap_original do |original, path|
         load_order << path
         original.call(path)
       end

--- a/spec/evilution/runner_spec.rb
+++ b/spec/evilution/runner_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe Evilution::Runner do
       line: 3,
       column: 4,
       diff: "- a >= b\n+ a > b",
-      strip_sources!: nil
+      strip_sources!: nil,
+      unparseable?: false,
+      unified_diff: nil
     )
   end
 
@@ -125,7 +127,9 @@ RSpec.describe Evilution::Runner do
           line: 5,
           column: 0,
           diff: "- x\n+ nil",
-          strip_sources!: nil
+          strip_sources!: nil,
+          unparseable?: false,
+          unified_diff: nil
         )
       end
 
@@ -844,7 +848,8 @@ RSpec.describe Evilution::Runner do
 
     it "passes spec_files to the RSpec integration" do
       expect(Evilution::Integration::RSpec).to receive(:new)
-        .with(test_files: ["spec/example_spec.rb"], hooks: nil, fallback_to_full_suite: anything, related_specs_heuristic: anything)
+        .with(test_files: ["spec/example_spec.rb"], hooks: nil, fallback_to_full_suite: anything,
+              related_specs_heuristic: anything, spec_selector: anything, example_filter: anything)
         .and_call_original
 
       runner.call
@@ -863,7 +868,8 @@ RSpec.describe Evilution::Runner do
       empty_runner = described_class.new(config: empty_config)
 
       expect(Evilution::Integration::RSpec).to receive(:new)
-        .with(test_files: nil, hooks: nil, fallback_to_full_suite: anything, related_specs_heuristic: anything)
+        .with(test_files: nil, hooks: nil, fallback_to_full_suite: anything,
+              related_specs_heuristic: anything, spec_selector: anything, example_filter: anything)
         .and_call_original
 
       empty_runner.call
@@ -900,7 +906,7 @@ RSpec.describe Evilution::Runner do
 
     it "dispatches to Integration::Minitest" do
       expect(Evilution::Integration::Minitest).to receive(:new)
-        .with(test_files: nil, hooks: nil, fallback_to_full_suite: anything).and_call_original
+        .with(test_files: nil, hooks: nil, fallback_to_full_suite: anything, spec_selector: anything).and_call_original
 
       runner.call
     end
@@ -920,7 +926,8 @@ RSpec.describe Evilution::Runner do
       minitest_runner = described_class.new(config: minitest_config)
 
       expect(Evilution::Integration::Minitest).to receive(:new)
-        .with(test_files: ["test/example_test.rb"], hooks: nil, fallback_to_full_suite: anything).and_call_original
+        .with(test_files: ["test/example_test.rb"], hooks: nil, fallback_to_full_suite: anything,
+              spec_selector: anything).and_call_original
 
       minitest_runner.call
     end
@@ -955,7 +962,7 @@ RSpec.describe Evilution::Runner do
 
     it "passes integration baseline_runner to Baseline" do
       expect(Evilution::Baseline).to receive(:new).with(
-        hash_including(runner: an_instance_of(Proc))
+        hash_including(runner: an_instance_of(Evilution::Integration::RSpec::BaselineRunner))
       ).and_call_original
 
       runner.call
@@ -1005,7 +1012,9 @@ RSpec.describe Evilution::Runner do
         line: 5,
         column: 0,
         diff: "- x\n+ nil",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
     end
 
@@ -1020,7 +1029,9 @@ RSpec.describe Evilution::Runner do
         line: 7,
         column: 0,
         diff: "- true\n+ false",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
     end
 
@@ -1413,7 +1424,9 @@ RSpec.describe Evilution::Runner do
         line: 5,
         column: 0,
         diff: "- x\n+ nil",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
       survived2 = Evilution::Result::MutationResult.new(
         mutation: mutation2, status: :survived, duration: 0.1
@@ -1590,7 +1603,9 @@ RSpec.describe Evilution::Runner do
         line: 5,
         column: 4,
         diff: "- true\n+ false",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
     end
 
@@ -1734,7 +1749,9 @@ RSpec.describe Evilution::Runner do
         line: 7,
         column: 4,
         diff: "- nil\n+ 0",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
 
       registry = Evilution::Mutator::Registry.default
@@ -1891,7 +1908,7 @@ RSpec.describe Evilution::Runner do
              subject: subject_a, operator_name: "op_a",
              original_source: "a", mutated_source: "b",
              file_path: "lib/example.rb", line: 1, column: 0,
-             diff: "- a\n+ b", strip_sources!: nil)
+             diff: "- a\n+ b", strip_sources!: nil, unparseable?: false, unified_diff: nil)
     end
 
     let(:mutation_b) do
@@ -1899,7 +1916,7 @@ RSpec.describe Evilution::Runner do
              subject: subject_b, operator_name: "op_b",
              original_source: "c", mutated_source: "d",
              file_path: "lib/example.rb", line: 10, column: 0,
-             diff: "- c\n+ d", strip_sources!: nil)
+             diff: "- c\n+ d", strip_sources!: nil, unparseable?: false, unified_diff: nil)
     end
 
     before do
@@ -2185,7 +2202,9 @@ RSpec.describe Evilution::Runner do
         line: 5,
         column: 4,
         diff: "- a >= b\n+ a > b",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
     end
 
@@ -2200,7 +2219,9 @@ RSpec.describe Evilution::Runner do
         line: 10,
         column: 4,
         diff: "- true\n+ false",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
     end
 
@@ -2297,7 +2318,9 @@ RSpec.describe Evilution::Runner do
         line: 4,
         column: 4,
         diff: "- true\n+ false",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
     end
 
@@ -2312,7 +2335,9 @@ RSpec.describe Evilution::Runner do
         line: 10,
         column: 4,
         diff: "- a >= b\n+ a > b",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
     end
 
@@ -2438,7 +2463,8 @@ RSpec.describe Evilution::Runner do
       allow(isolator).to receive(:call).and_return(mutation_result)
 
       expect(Evilution::Integration::RSpec).to receive(:new)
-        .with(test_files: nil, hooks: hooks, fallback_to_full_suite: anything, related_specs_heuristic: anything)
+        .with(test_files: nil, hooks: hooks, fallback_to_full_suite: anything,
+              related_specs_heuristic: anything, spec_selector: anything, example_filter: anything)
         .and_call_original
 
       hooked_runner = described_class.new(
@@ -2467,7 +2493,9 @@ RSpec.describe Evilution::Runner do
         line: 5,
         column: 4,
         diff: "- true\n+ false",
-        strip_sources!: nil
+        strip_sources!: nil,
+        unparseable?: false,
+        unified_diff: nil
       )
 
       registry = instance_double(Evilution::Mutator::Registry)


### PR DESCRIPTION
- Introduced tests for world example groups, filtered examples, and sources by path to ensure proper snapshot and release functionality.
- Implemented state guard tests to validate the preservation of RSpec world state across runs.
- Enhanced TestFileResolver and UnresolvedSpecWarner with comprehensive tests for expected behavior.
- Updated runner tests to verify integration with RSpec and ensure proper handling of hooks and error propagation.
- Added memory stats tests to monitor memory usage during mutation testing.
- Refactored existing tests to align with new functionality and ensure backward compatibility.