### PR TITLE
846: Add tests for mutation executor components and strategies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,8 +26,6 @@ Metrics/BlockLength:
 # target 150
 Metrics/ClassLength:
   Max: 150
-  Exclude:
-    - "lib/evilution/runner/mutation_executor.rb"
 
 Metrics/ModuleLength:
   Exclude:

--- a/lib/evilution/runner/mutation_executor.rb
+++ b/lib/evilution/runner/mutation_executor.rb
@@ -47,7 +47,7 @@ class Evilution::Runner::MutationExecutor
   end
 
   def build_notifier
-    ResultNotifier.new(@config, hooks: @hooks, diagnostics: @diagnostics, on_result: @on_result)
+    ResultNotifier.new(@config, diagnostics: @diagnostics, on_result: @on_result)
   end
 
   def build_pipeline(spec_resolver)

--- a/lib/evilution/runner/mutation_executor.rb
+++ b/lib/evilution/runner/mutation_executor.rb
@@ -1,325 +1,94 @@
 # frozen_string_literal: true
 
 require_relative "../parallel/pool"
-require_relative "../reporter/progress_bar"
-require_relative "../result/mutation_result"
+require_relative "mutation_executor/result_cache"
+require_relative "mutation_executor/result_packer"
+require_relative "mutation_executor/result_notifier"
+require_relative "mutation_executor/mutation_runner"
+require_relative "mutation_executor/neutralization_pipeline"
+require_relative "mutation_executor/neutralizer/infra_error"
+require_relative "mutation_executor/neutralizer/baseline_failed"
+require_relative "mutation_executor/strategy/sequential"
+require_relative "mutation_executor/strategy/parallel"
 
 class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
 
 class Evilution::Runner::MutationExecutor
+  InfraError = Neutralizer::InfraError
+  BaselineFailed = Neutralizer::BaselineFailed
+  Sequential = Strategy::Sequential
+  Parallel = Strategy::Parallel
+
   def initialize(config, isolator:, baseline_runner:, cache:, hooks:, diagnostics:, on_result: nil)
     @config = config
     @isolator = isolator
     @baseline_runner = baseline_runner
-    @cache = cache
+    @cache = ResultCache.new(cache)
+    @packer = ResultPacker.new
     @hooks = hooks
     @diagnostics = diagnostics
     @on_result = on_result
   end
 
   def call(mutations, baseline_result = nil)
-    @progress_bar = build_progress_bar(mutations.length)
-    result = if config.jobs > 1
-               run_parallel(mutations, baseline_result)
-             else
-               run_sequential(mutations, baseline_result)
-             end
-    @progress_bar&.finish
-    result
+    integration = @baseline_runner.build_integration
+    spec_resolver = baseline_failed?(baseline_result) ? @baseline_runner.neutralization_resolver : nil
+    notifier = build_notifier
+    pipeline = build_pipeline(spec_resolver)
+    strategy = @config.jobs > 1 ? build_parallel(notifier, pipeline) : build_sequential(notifier, pipeline)
+
+    strategy.call(mutations, baseline_result: baseline_result, integration: integration)
   end
 
   private
 
-  attr_reader :config, :isolator, :baseline_runner, :cache, :hooks, :diagnostics, :on_result
-
-  def run_sequential(mutations, baseline_result)
-    integration = baseline_runner.build_integration
-    spec_resolver = baseline_result&.failed? ? baseline_runner.neutralization_resolver : nil
-    results = []
-    survived_count = 0
-    truncated = false
-
-    mutations.each_with_index do |mutation, index|
-      result = execute_one(mutation, integration)
-      mutation.strip_sources!
-      result = neutralize_if_infra_error(result)
-      result = neutralize_if_baseline_failed(result, baseline_result, spec_resolver)
-      results << result
-      survived_count += 1 if result.survived?
-      notify_result(result, index + 1)
-
-      if config.fail_fast? && survived_count >= config.fail_fast
-        truncated = true
-        break
-      end
-    end
-
-    [results, truncated]
+  def baseline_failed?(baseline_result)
+    baseline_result && baseline_result.failed?
   end
 
-  def run_parallel(mutations, baseline_result)
-    integration = baseline_runner.build_integration
-    pool = build_pool
-    spec_resolver = baseline_result&.failed? ? baseline_runner.neutralization_resolver : nil
-    state = { results: [], survived_count: 0, truncated: false, completed: 0 }
-    all_worker_stats = []
+  def build_notifier
+    ResultNotifier.new(@config, hooks: @hooks, diagnostics: @diagnostics, on_result: @on_result)
+  end
 
-    mutations.each_slice(config.jobs) do |batch|
-      break if state[:truncated]
+  def build_pipeline(spec_resolver)
+    NeutralizationPipeline.new(
+      [
+        InfraError.new,
+        BaselineFailed.new(
+          config: @config,
+          spec_resolver: spec_resolver || ->(_f) {},
+          fallback_dir: @baseline_runner.neutralization_fallback_dir
+        )
+      ]
+    )
+  end
 
-      batch_results = run_parallel_batch(batch, pool, isolator, integration)
-      all_worker_stats.concat(pool.worker_stats)
-      process_batch(batch_results, baseline_result, spec_resolver, state)
-    end
+  def build_sequential(notifier, pipeline)
+    Sequential.new(
+      runner: MutationRunner.new(config: @config, cache: @cache, isolator: @isolator),
+      pipeline: pipeline,
+      notifier: notifier
+    )
+  end
 
-    diagnostics.log_worker_stats(diagnostics.aggregate_worker_stats(all_worker_stats))
-    [state[:results], state[:truncated]]
+  def build_parallel(notifier, pipeline)
+    Parallel.new(
+      cache: @cache,
+      isolator: @isolator,
+      packer: @packer,
+      pipeline: pipeline,
+      notifier: notifier,
+      pool_factory: -> { build_pool },
+      diagnostics: @diagnostics,
+      config: @config
+    )
   end
 
   def build_pool
     Evilution::Parallel::Pool.new(
-      size: config.jobs,
-      hooks: hooks,
-      item_timeout: config.timeout ? config.timeout * 2 : nil
+      size: @config.jobs,
+      hooks: @hooks,
+      item_timeout: @config.timeout ? @config.timeout * 2 : nil
     )
-  end
-
-  def run_parallel_batch(batch, pool, worker_isolator, integration)
-    uncached_indices, cached_results = partition_cached(batch)
-    worker_results = run_uncached_workers(batch, uncached_indices, pool, worker_isolator, integration)
-    compact_results = merge_parallel_results(batch, uncached_indices, cached_results, worker_results)
-    batch.each(&:strip_sources!)
-    batch_results = rebuild_results(batch, compact_results)
-    batch_results.each { |r| store_cached_result(r.mutation, r) }
-    batch_results
-  end
-
-  def run_uncached_workers(batch, uncached_indices, pool, worker_isolator, integration)
-    return [] if uncached_indices.empty?
-
-    uncached = uncached_indices.map { |i| batch[i] }
-    pool.map(uncached) do |mutation|
-      test_command = ->(m) { integration.call(m) }
-      result = worker_isolator.call(mutation: mutation, test_command: test_command, timeout: config.timeout)
-      compact_result(result)
-    end
-  end
-
-  def process_batch(batch_results, baseline_result, spec_resolver, state)
-    batch_results.each do |result|
-      result = neutralize_if_infra_error(result)
-      result = neutralize_if_baseline_failed(result, baseline_result, spec_resolver)
-      state[:results] << result
-      state[:survived_count] += 1 if result.survived?
-      state[:completed] += 1
-      notify_result(result, state[:completed])
-    end
-
-    diagnostics.log_memory("after batch", "#{state[:completed]} complete")
-    state[:truncated] = true if should_truncate?(state[:survived_count])
-  end
-
-  # Reclassify results as :neutral when the failure was caused by test
-  # infrastructure rather than by the mutation. Two independent paths:
-  #
-  # 1) :error from a missing require / spec_helper / rails_helper / spec/support
-  #    initialization — detected by error_class ∈ INFRA_ERROR_CLASSES and
-  #    first backtrace frame matching INFRA_BACKTRACE_PATHS. Origin-only match
-  #    (not `any?`): Ruby backtraces typically carry spec_helper frames below
-  #    mutation-caused errors, so matching any frame would misclassify real
-  #    mutation NameError/LoadError as :neutral.
-  #
-  # 2) :killed from a CrashDetector test_crashed whose sole crash class is in
-  #    INFRA_CRASH_CLASSES (ActiveRecord::StatementTimeout, Timeout::Error,
-  #    etc.). These surface under parallel workers sharing a DB file or on a
-  #    slow CI; fork.rb initially reports them as :killed, and without this
-  #    demotion the kill count inflates with infra noise. No backtrace check:
-  #    the single-class signal from CrashDetector already rules out mixed
-  #    mutation-caused failures. See EV-toid / GH #814.
-  INFRA_ERROR_CLASSES = %w[LoadError NameError].freeze
-  INFRA_BACKTRACE_PATHS = %r{(?:^|/)(?:spec_helper\.rb|rails_helper\.rb|spec/support/)}
-  INFRA_CRASH_CLASSES = %w[
-    Timeout::Error
-    ActiveRecord::StatementTimeout
-    ActiveRecord::Deadlocked
-    ActiveRecord::ConnectionTimeoutError
-    ActiveRecord::LockWaitTimeout
-    SQLite3::BusyException
-  ].freeze
-  private_constant :INFRA_ERROR_CLASSES, :INFRA_BACKTRACE_PATHS, :INFRA_CRASH_CLASSES
-
-  def neutralize_if_infra_error(result)
-    return neutralize(result) if infra_crash?(result)
-    return result unless result.error?
-    return result unless INFRA_ERROR_CLASSES.include?(result.error_class)
-    return result unless infra_origin?(result.error_backtrace)
-
-    neutralize(result)
-  end
-
-  def infra_crash?(result)
-    result.killed? && INFRA_CRASH_CLASSES.include?(result.error_class)
-  end
-
-  def infra_origin?(backtrace)
-    frames = Array(backtrace)
-    return false if frames.empty?
-
-    frames.first =~ INFRA_BACKTRACE_PATHS ? true : false
-  end
-
-  def neutralize(result)
-    Evilution::Result::MutationResult.new(
-      mutation: result.mutation,
-      status: :neutral,
-      duration: result.duration,
-      test_command: result.test_command,
-      child_rss_kb: result.child_rss_kb,
-      memory_delta_kb: result.memory_delta_kb,
-      parent_rss_kb: result.parent_rss_kb,
-      error_message: result.error_message,
-      error_class: result.error_class,
-      error_backtrace: result.error_backtrace
-    )
-  end
-
-  def neutralize_if_baseline_failed(result, baseline_result, spec_resolver)
-    return result unless result.survived? && baseline_result && baseline_result.failed?
-
-    if config.spec_files.any?
-      should_neutralize = true
-    else
-      spec_file = spec_resolver.call(result.mutation.file_path) || baseline_runner.neutralization_fallback_dir
-      should_neutralize = baseline_result.failed_spec_files.include?(spec_file)
-    end
-    return result unless should_neutralize
-
-    neutralize(result)
-  end
-
-  def compact_result(result)
-    {
-      status: result.status,
-      duration: result.duration,
-      killing_test: result.killing_test,
-      test_command: result.test_command,
-      child_rss_kb: result.child_rss_kb,
-      memory_delta_kb: result.memory_delta_kb,
-      parent_rss_kb: result.parent_rss_kb,
-      error_message: result.error_message,
-      error_class: result.error_class,
-      error_backtrace: result.error_backtrace
-    }
-  end
-
-  def rebuild_results(batch, compact_results)
-    batch.zip(compact_results).map do |mutation, data|
-      Evilution::Result::MutationResult.new(
-        mutation: mutation,
-        status: data[:status],
-        duration: data[:duration],
-        killing_test: data[:killing_test],
-        test_command: data[:test_command],
-        child_rss_kb: data[:child_rss_kb],
-        memory_delta_kb: data[:memory_delta_kb],
-        parent_rss_kb: data[:parent_rss_kb],
-        error_message: data[:error_message],
-        error_class: data[:error_class],
-        error_backtrace: data[:error_backtrace]
-      )
-    end
-  end
-
-  def should_truncate?(survived_count)
-    config.fail_fast? && survived_count >= config.fail_fast
-  end
-
-  def partition_cached(batch)
-    uncached_indices = []
-    cached_results = {}
-
-    batch.each_with_index do |mutation, i|
-      if mutation.unparseable?
-        cached_results[i] = compact_result(build_unparseable_result(mutation))
-        next
-      end
-
-      cached = fetch_cached_result(mutation)
-      if cached
-        cached_results[i] = compact_result(cached)
-      else
-        uncached_indices << i
-      end
-    end
-
-    [uncached_indices, cached_results]
-  end
-
-  def execute_one(mutation, integration)
-    return build_unparseable_result(mutation) if mutation.unparseable?
-
-    execute_or_fetch(mutation) do
-      test_command = ->(m) { integration.call(m) }
-      isolator.call(mutation: mutation, test_command: test_command, timeout: config.timeout)
-    end
-  end
-
-  def build_unparseable_result(mutation)
-    Evilution::Result::MutationResult.new(mutation: mutation, status: :unparseable)
-  end
-
-  def merge_parallel_results(batch, uncached_indices, cached_results, worker_results)
-    result_map = cached_results.dup
-    uncached_indices.each_with_index { |batch_idx, worker_idx| result_map[batch_idx] = worker_results[worker_idx] }
-    batch.each_index.map { |i| result_map[i] }
-  end
-
-  def execute_or_fetch(mutation)
-    cached = fetch_cached_result(mutation)
-    return cached if cached
-
-    result = yield
-    store_cached_result(mutation, result)
-    result
-  end
-
-  def fetch_cached_result(mutation)
-    return nil unless cache
-
-    data = cache.fetch(mutation)
-    return nil unless data
-    return nil unless %i[killed timeout].include?(data[:status])
-
-    Evilution::Result::MutationResult.new(
-      mutation: mutation,
-      status: data[:status],
-      duration: data[:duration],
-      killing_test: data[:killing_test],
-      test_command: data[:test_command]
-    )
-  end
-
-  def store_cached_result(mutation, result)
-    return unless cache
-    return unless result.killed? || result.timeout?
-
-    cache.store(mutation,
-                status: result.status,
-                duration: result.duration,
-                killing_test: result.killing_test,
-                test_command: result.test_command)
-  end
-
-  def notify_result(result, index)
-    on_result&.call(result)
-    @progress_bar&.tick(status: result.status)
-    diagnostics.log_progress(index, result.status)
-    diagnostics.log_mutation_diagnostics(result)
-  end
-
-  def build_progress_bar(total)
-    return nil if !config.progress? || config.quiet || config.verbose || !config.text? || !$stderr.tty?
-
-    Evilution::Reporter::ProgressBar.new(total: total, output: $stderr)
   end
 end

--- a/lib/evilution/runner/mutation_executor/mutation_runner.rb
+++ b/lib/evilution/runner/mutation_executor/mutation_runner.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../../result/mutation_result"
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+
+class Evilution::Runner::MutationExecutor::MutationRunner
+  def initialize(config:, cache:, isolator:)
+    @config = config
+    @cache = cache
+    @isolator = isolator
+  end
+
+  def call(mutation, integration:)
+    return unparseable_result(mutation) if mutation.unparseable?
+
+    cached = @cache.fetch(mutation)
+    return cached if cached
+
+    test_command = ->(m) { integration.call(m) }
+    result = @isolator.call(mutation: mutation, test_command: test_command, timeout: @config.timeout)
+    @cache.store(mutation, result)
+    result
+  end
+
+  private
+
+  def unparseable_result(mutation)
+    Evilution::Result::MutationResult.new(mutation: mutation, status: :unparseable)
+  end
+end

--- a/lib/evilution/runner/mutation_executor/neutralization_pipeline.rb
+++ b/lib/evilution/runner/mutation_executor/neutralization_pipeline.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+
+class Evilution::Runner::MutationExecutor::NeutralizationPipeline
+  def initialize(neutralizers)
+    @neutralizers = neutralizers
+  end
+
+  def call(result, **ctx)
+    @neutralizers.reduce(result) do |acc, nz|
+      ctx.empty? ? nz.call(acc) : nz.call(acc, **ctx)
+    end
+  end
+end

--- a/lib/evilution/runner/mutation_executor/neutralizer/baseline_failed.rb
+++ b/lib/evilution/runner/mutation_executor/neutralizer/baseline_failed.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../../../result/mutation_result"
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+module Evilution::Runner::MutationExecutor::Neutralizer; end unless defined?(Evilution::Runner::MutationExecutor::Neutralizer)
+
+class Evilution::Runner::MutationExecutor::Neutralizer::BaselineFailed
+  def initialize(config:, spec_resolver:, fallback_dir:)
+    @config = config
+    @spec_resolver = spec_resolver
+    @fallback_dir = fallback_dir
+  end
+
+  def call(result, baseline_result:)
+    return result unless result.survived? && baseline_result && baseline_result.failed?
+
+    if @config.spec_files.any?
+      should_neutralize = true
+    else
+      spec_file = @spec_resolver.call(result.mutation.file_path) || @fallback_dir
+      should_neutralize = baseline_result.failed_spec_files.include?(spec_file)
+    end
+    return result unless should_neutralize
+
+    neutralize(result)
+  end
+
+  private
+
+  def neutralize(result)
+    Evilution::Result::MutationResult.new(
+      mutation: result.mutation,
+      status: :neutral,
+      duration: result.duration,
+      test_command: result.test_command,
+      child_rss_kb: result.child_rss_kb,
+      memory_delta_kb: result.memory_delta_kb,
+      parent_rss_kb: result.parent_rss_kb,
+      error_message: result.error_message,
+      error_class: result.error_class,
+      error_backtrace: result.error_backtrace
+    )
+  end
+end

--- a/lib/evilution/runner/mutation_executor/neutralizer/infra_error.rb
+++ b/lib/evilution/runner/mutation_executor/neutralizer/infra_error.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative "../../../result/mutation_result"
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+module Evilution::Runner::MutationExecutor::Neutralizer; end unless defined?(Evilution::Runner::MutationExecutor::Neutralizer)
+
+# Reclassify results as :neutral when the failure was caused by test
+# infrastructure rather than by the mutation. Two independent paths:
+#
+# 1) :error from a missing require / spec_helper / rails_helper / spec/support
+#    initialization — detected by error_class ∈ INFRA_ERROR_CLASSES and
+#    first backtrace frame matching INFRA_BACKTRACE_PATHS. Origin-only match
+#    (not `any?`): Ruby backtraces typically carry spec_helper frames below
+#    mutation-caused errors, so matching any frame would misclassify real
+#    mutation NameError/LoadError as :neutral.
+#
+# 2) :killed from a CrashDetector test_crashed whose sole crash class is in
+#    INFRA_CRASH_CLASSES (ActiveRecord::StatementTimeout, Timeout::Error,
+#    etc.). These surface under parallel workers sharing a DB file or on a
+#    slow CI; fork.rb initially reports them as :killed, and without this
+#    demotion the kill count inflates with infra noise. No backtrace check:
+#    the single-class signal from CrashDetector already rules out mixed
+#    mutation-caused failures. See EV-toid / GH #814.
+class Evilution::Runner::MutationExecutor::Neutralizer::InfraError
+  INFRA_ERROR_CLASSES = %w[LoadError NameError].freeze
+  INFRA_BACKTRACE_PATHS = %r{(?:^|/)(?:spec_helper\.rb|rails_helper\.rb|spec/support/)}
+  INFRA_CRASH_CLASSES = %w[
+    Timeout::Error
+    ActiveRecord::StatementTimeout
+    ActiveRecord::Deadlocked
+    ActiveRecord::ConnectionTimeoutError
+    ActiveRecord::LockWaitTimeout
+    SQLite3::BusyException
+  ].freeze
+  private_constant :INFRA_ERROR_CLASSES, :INFRA_BACKTRACE_PATHS, :INFRA_CRASH_CLASSES
+
+  def call(result, **_ctx)
+    return neutralize(result) if infra_crash?(result)
+    return result unless result.error?
+    return result unless INFRA_ERROR_CLASSES.include?(result.error_class)
+    return result unless infra_origin?(result.error_backtrace)
+
+    neutralize(result)
+  end
+
+  private
+
+  def infra_crash?(result)
+    result.killed? && INFRA_CRASH_CLASSES.include?(result.error_class)
+  end
+
+  def infra_origin?(backtrace)
+    frames = Array(backtrace)
+    return false if frames.empty?
+
+    frames.first =~ INFRA_BACKTRACE_PATHS ? true : false
+  end
+
+  def neutralize(result)
+    Evilution::Result::MutationResult.new(
+      mutation: result.mutation,
+      status: :neutral,
+      duration: result.duration,
+      test_command: result.test_command,
+      child_rss_kb: result.child_rss_kb,
+      memory_delta_kb: result.memory_delta_kb,
+      parent_rss_kb: result.parent_rss_kb,
+      error_message: result.error_message,
+      error_class: result.error_class,
+      error_backtrace: result.error_backtrace
+    )
+  end
+end

--- a/lib/evilution/runner/mutation_executor/result_cache.rb
+++ b/lib/evilution/runner/mutation_executor/result_cache.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative "../../result/mutation_result"
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+
+class Evilution::Runner::MutationExecutor::ResultCache
+  CACHEABLE_STATUSES = %i[killed timeout].freeze
+  private_constant :CACHEABLE_STATUSES
+
+  def initialize(backend)
+    @backend = backend
+  end
+
+  def fetch(mutation)
+    return nil unless @backend
+
+    data = @backend.fetch(mutation)
+    return nil unless data
+    return nil unless CACHEABLE_STATUSES.include?(data[:status])
+
+    Evilution::Result::MutationResult.new(
+      mutation: mutation,
+      status: data[:status],
+      duration: data[:duration],
+      killing_test: data[:killing_test],
+      test_command: data[:test_command]
+    )
+  end
+
+  def store(mutation, result)
+    return unless @backend
+    return unless result.killed? || result.timeout?
+
+    @backend.store(mutation,
+                   status: result.status,
+                   duration: result.duration,
+                   killing_test: result.killing_test,
+                   test_command: result.test_command)
+  end
+
+  def partition(batch, packer:)
+    uncached_indices = []
+    cached_results = {}
+
+    batch.each_with_index do |mutation, i|
+      if mutation.unparseable?
+        cached_results[i] = packer.compact(unparseable_result(mutation))
+        next
+      end
+
+      cached = fetch(mutation)
+      if cached
+        cached_results[i] = packer.compact(cached)
+      else
+        uncached_indices << i
+      end
+    end
+
+    [uncached_indices, cached_results]
+  end
+
+  private
+
+  def unparseable_result(mutation)
+    Evilution::Result::MutationResult.new(mutation: mutation, status: :unparseable)
+  end
+end

--- a/lib/evilution/runner/mutation_executor/result_notifier.rb
+++ b/lib/evilution/runner/mutation_executor/result_notifier.rb
@@ -6,9 +6,8 @@ class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disabl
 class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
 
 class Evilution::Runner::MutationExecutor::ResultNotifier
-  def initialize(config, hooks:, diagnostics:, on_result:)
+  def initialize(config, diagnostics:, on_result:)
     @config = config
-    @hooks = hooks
     @diagnostics = diagnostics
     @on_result = on_result
     @survived_count = 0

--- a/lib/evilution/runner/mutation_executor/result_notifier.rb
+++ b/lib/evilution/runner/mutation_executor/result_notifier.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../../reporter/progress_bar"
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+
+class Evilution::Runner::MutationExecutor::ResultNotifier
+  def initialize(config, hooks:, diagnostics:, on_result:)
+    @config = config
+    @hooks = hooks
+    @diagnostics = diagnostics
+    @on_result = on_result
+    @survived_count = 0
+    @progress_bar = nil
+  end
+
+  attr_reader :survived_count
+
+  def start(total)
+    @survived_count = 0
+    @progress_bar = build_progress_bar(total)
+  end
+
+  def notify(result, index)
+    @on_result.call(result) if @on_result
+    @progress_bar.tick(status: result.status) if @progress_bar
+    @diagnostics.log_progress(index, result.status)
+    @diagnostics.log_mutation_diagnostics(result)
+    @survived_count += 1 if result.survived?
+    truncate? ? :truncate : :continue
+  end
+
+  def finish
+    @progress_bar.finish if @progress_bar
+  end
+
+  private
+
+  def truncate?
+    @config.fail_fast? && @survived_count >= @config.fail_fast
+  end
+
+  def build_progress_bar(total)
+    return nil if !@config.progress? || @config.quiet || @config.verbose || !@config.text? || !$stderr.tty?
+
+    Evilution::Reporter::ProgressBar.new(total: total, output: $stderr)
+  end
+end

--- a/lib/evilution/runner/mutation_executor/result_packer.rb
+++ b/lib/evilution/runner/mutation_executor/result_packer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../../result/mutation_result"
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+
+class Evilution::Runner::MutationExecutor::ResultPacker
+  def compact(result)
+    {
+      status: result.status,
+      duration: result.duration,
+      killing_test: result.killing_test,
+      test_command: result.test_command,
+      child_rss_kb: result.child_rss_kb,
+      memory_delta_kb: result.memory_delta_kb,
+      parent_rss_kb: result.parent_rss_kb,
+      error_message: result.error_message,
+      error_class: result.error_class,
+      error_backtrace: result.error_backtrace
+    }
+  end
+
+  def rebuild(mutation, data)
+    Evilution::Result::MutationResult.new(
+      mutation: mutation,
+      status: data[:status],
+      duration: data[:duration],
+      killing_test: data[:killing_test],
+      test_command: data[:test_command],
+      child_rss_kb: data[:child_rss_kb],
+      memory_delta_kb: data[:memory_delta_kb],
+      parent_rss_kb: data[:parent_rss_kb],
+      error_message: data[:error_message],
+      error_class: data[:error_class],
+      error_backtrace: data[:error_backtrace]
+    )
+  end
+end

--- a/lib/evilution/runner/mutation_executor/strategy/parallel.rb
+++ b/lib/evilution/runner/mutation_executor/strategy/parallel.rb
@@ -43,7 +43,7 @@ class Evilution::Runner::MutationExecutor::Strategy::Parallel
     compact_results = merge(batch, uncached_indices, cached_results, worker_results)
     batch.each(&:strip_sources!)
     batch_results = batch.zip(compact_results).map { |m, h| @packer.rebuild(m, h) }
-    batch_results.each { |r| @cache.store(r.mutation, r) }
+    uncached_indices.each { |i| @cache.store(batch_results[i].mutation, batch_results[i]) }
     batch_results
   end
 

--- a/lib/evilution/runner/mutation_executor/strategy/parallel.rb
+++ b/lib/evilution/runner/mutation_executor/strategy/parallel.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+module Evilution::Runner::MutationExecutor::Strategy; end unless defined?(Evilution::Runner::MutationExecutor::Strategy)
+
+class Evilution::Runner::MutationExecutor::Strategy::Parallel
+  def initialize(cache:, isolator:, packer:, pipeline:, notifier:, pool_factory:, config:, diagnostics: nil)
+    @cache = cache
+    @isolator = isolator
+    @packer = packer
+    @pipeline = pipeline
+    @notifier = notifier
+    @pool_factory = pool_factory
+    @diagnostics = diagnostics
+    @config = config
+  end
+
+  def call(mutations, baseline_result:, integration:)
+    @notifier.start(mutations.length)
+    pool = @pool_factory.call
+    state = { results: [], truncated: false, completed: 0 }
+    all_worker_stats = []
+
+    mutations.each_slice(@config.jobs) do |batch|
+      break if state[:truncated]
+
+      batch_results = run_batch(batch, pool, integration)
+      all_worker_stats.concat(pool.worker_stats)
+      process_batch(batch_results, baseline_result, state)
+    end
+
+    @diagnostics.log_worker_stats(@diagnostics.aggregate_worker_stats(all_worker_stats)) if @diagnostics
+    @notifier.finish
+    [state[:results], state[:truncated]]
+  end
+
+  private
+
+  def run_batch(batch, pool, integration)
+    uncached_indices, cached_results = @cache.partition(batch, packer: @packer)
+    worker_results = run_uncached(batch, uncached_indices, pool, integration)
+    compact_results = merge(batch, uncached_indices, cached_results, worker_results)
+    batch.each(&:strip_sources!)
+    batch_results = batch.zip(compact_results).map { |m, h| @packer.rebuild(m, h) }
+    batch_results.each { |r| @cache.store(r.mutation, r) }
+    batch_results
+  end
+
+  def run_uncached(batch, uncached_indices, pool, integration)
+    return [] if uncached_indices.empty?
+
+    uncached = uncached_indices.map { |i| batch[i] }
+    pool.map(uncached) do |mutation|
+      test_command = ->(m) { integration.call(m) }
+      result = @isolator.call(mutation: mutation, test_command: test_command, timeout: @config.timeout)
+      @packer.compact(result)
+    end
+  end
+
+  def merge(batch, uncached_indices, cached_results, worker_results)
+    result_map = cached_results.dup
+    uncached_indices.each_with_index { |batch_idx, worker_idx| result_map[batch_idx] = worker_results[worker_idx] }
+    batch.each_index.map { |i| result_map[i] }
+  end
+
+  def process_batch(batch_results, baseline_result, state)
+    batch_results.each do |result|
+      result = @pipeline.call(result, baseline_result: baseline_result)
+      state[:results] << result
+      state[:completed] += 1
+      if @notifier.notify(result, state[:completed]) == :truncate
+        state[:truncated] = true
+        break
+      end
+    end
+
+    @diagnostics.log_memory("after batch", "#{state[:completed]} complete") if @diagnostics
+  end
+end

--- a/lib/evilution/runner/mutation_executor/strategy/sequential.rb
+++ b/lib/evilution/runner/mutation_executor/strategy/sequential.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Evilution::Runner; end unless defined?(Evilution::Runner) # rubocop:disable Lint/EmptyClass
+class Evilution::Runner::MutationExecutor; end unless defined?(Evilution::Runner::MutationExecutor) # rubocop:disable Lint/EmptyClass
+module Evilution::Runner::MutationExecutor::Strategy; end unless defined?(Evilution::Runner::MutationExecutor::Strategy)
+
+class Evilution::Runner::MutationExecutor::Strategy::Sequential
+  def initialize(runner:, pipeline:, notifier:)
+    @runner = runner
+    @pipeline = pipeline
+    @notifier = notifier
+  end
+
+  def call(mutations, baseline_result:, integration:)
+    @notifier.start(mutations.length)
+    results = []
+    truncated = false
+
+    mutations.each_with_index do |mutation, index|
+      result = @runner.call(mutation, integration: integration)
+      mutation.strip_sources!
+      result = @pipeline.call(result, baseline_result: baseline_result)
+      results << result
+
+      if @notifier.notify(result, index + 1) == :truncate
+        truncated = true
+        break
+      end
+    end
+
+    @notifier.finish
+    [results, truncated]
+  end
+end

--- a/spec/evilution/runner/mutation_executor/mutation_runner_spec.rb
+++ b/spec/evilution/runner/mutation_executor/mutation_runner_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "evilution/config"
+require "evilution/mutation"
+require "evilution/result/mutation_result"
+require "evilution/runner/mutation_executor/result_cache"
+require "evilution/runner/mutation_executor/mutation_runner"
+
+RSpec.describe Evilution::Runner::MutationExecutor::MutationRunner do
+  let(:cfg) { Evilution::Config.new(quiet: true, baseline: false, skip_config_file: true, timeout: 30) }
+
+  def mutation(unparseable: false)
+    instance_double(Evilution::Mutation, file_path: "lib/foo.rb", unparseable?: unparseable)
+  end
+
+  def killed(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :killed, duration: 0.1, killing_test: "t", test_command: "c")
+  end
+
+  def survived(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :survived, duration: 0.1)
+  end
+
+  def cache_with(backend = nil)
+    Evilution::Runner::MutationExecutor::ResultCache.new(backend)
+  end
+
+  it "returns an :unparseable result when mutation.unparseable? is true (no isolator call)" do
+    mut = mutation(unparseable: true)
+    isolator = double(:isolator)
+    expect(isolator).not_to receive(:call)
+
+    runner = described_class.new(config: cfg, cache: cache_with, isolator: isolator)
+    out = runner.call(mut, integration: ->(_) { "cmd" })
+    expect(out.status).to eq(:unparseable)
+  end
+
+  it "returns the cached result without calling isolator when cache hit" do
+    mut = mutation
+    backend = instance_double("Cache", fetch: { status: :killed, duration: 0.2, killing_test: "t", test_command: "c" })
+    isolator = double(:isolator)
+    expect(isolator).not_to receive(:call)
+
+    runner = described_class.new(config: cfg, cache: cache_with(backend), isolator: isolator)
+    out = runner.call(mut, integration: ->(_) { "cmd" })
+    expect(out.status).to eq(:killed)
+    expect(out.duration).to eq(0.2)
+  end
+
+  it "calls isolator on cache miss and stores killed result back into cache" do
+    mut = mutation
+    backend = instance_double("Cache", fetch: nil)
+    expect(backend).to receive(:store).with(mut, hash_including(status: :killed))
+    isolator = double(:isolator)
+    integration = ->(_) { "cmd" }
+
+    expect(isolator).to receive(:call) do |mutation:, test_command:, timeout:|
+      expect(mutation).to be(mut)
+      expect(test_command.call(:m)).to eq("cmd")
+      expect(timeout).to eq(30)
+      killed(mut)
+    end
+
+    runner = described_class.new(config: cfg, cache: cache_with(backend), isolator: isolator)
+    out = runner.call(mut, integration: integration)
+    expect(out.status).to eq(:killed)
+  end
+
+  it "does not store survived results in cache" do
+    mut = mutation
+    backend = instance_double("Cache", fetch: nil)
+    expect(backend).not_to receive(:store)
+    isolator = double(:isolator)
+    allow(isolator).to receive(:call).and_return(survived(mut))
+
+    runner = described_class.new(config: cfg, cache: cache_with(backend), isolator: isolator)
+    runner.call(mut, integration: ->(_) { "cmd" })
+  end
+end

--- a/spec/evilution/runner/mutation_executor/neutralization_pipeline_spec.rb
+++ b/spec/evilution/runner/mutation_executor/neutralization_pipeline_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "evilution/result/mutation_result"
+require "evilution/runner/mutation_executor/neutralization_pipeline"
+
+RSpec.describe Evilution::Runner::MutationExecutor::NeutralizationPipeline do
+  let(:mutation) { instance_double("Mutation") }
+  let(:result) { Evilution::Result::MutationResult.new(mutation: mutation, status: :survived, duration: 0.01) }
+
+  it "returns the original result when neutralizer list is empty" do
+    pipeline = described_class.new([])
+    expect(pipeline.call(result)).to be(result)
+  end
+
+  it "applies a single neutralizer and returns its output" do
+    nz = double(:nz)
+    out = Evilution::Result::MutationResult.new(mutation: mutation, status: :neutral, duration: 0.01)
+    allow(nz).to receive(:call).with(result, foo: 1).and_return(out)
+
+    pipeline = described_class.new([nz])
+    expect(pipeline.call(result, foo: 1)).to be(out)
+  end
+
+  it "chains neutralizers, threading each output as input to the next" do
+    nz1 = double(:nz1)
+    nz2 = double(:nz2)
+    mid = Evilution::Result::MutationResult.new(mutation: mutation, status: :neutral, duration: 0.01)
+    out = Evilution::Result::MutationResult.new(mutation: mutation, status: :neutral, duration: 0.02)
+    allow(nz1).to receive(:call).with(result).and_return(mid)
+    allow(nz2).to receive(:call).with(mid).and_return(out)
+
+    pipeline = described_class.new([nz1, nz2])
+    expect(pipeline.call(result)).to be(out)
+  end
+
+  it "passes ctx kwargs to every neutralizer" do
+    nz1 = double(:nz1)
+    nz2 = double(:nz2)
+    expect(nz1).to receive(:call).with(result, baseline_result: :bl).and_return(result)
+    expect(nz2).to receive(:call).with(result, baseline_result: :bl).and_return(result)
+
+    described_class.new([nz1, nz2]).call(result, baseline_result: :bl)
+  end
+end

--- a/spec/evilution/runner/mutation_executor/neutralizer/baseline_failed_spec.rb
+++ b/spec/evilution/runner/mutation_executor/neutralizer/baseline_failed_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "evilution/config"
+require "evilution/mutation"
+require "evilution/result/mutation_result"
+require "evilution/runner/mutation_executor/neutralizer/baseline_failed"
+
+RSpec.describe Evilution::Runner::MutationExecutor::Neutralizer::BaselineFailed do
+  def mutation(file: "lib/foo.rb")
+    instance_double(Evilution::Mutation, file_path: file)
+  end
+
+  def survived(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :survived, duration: 0.01)
+  end
+
+  def killed(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :killed, duration: 0.01)
+  end
+
+  def baseline_failed(failed_files: [])
+    instance_double("BaselineResult", failed?: true, failed_spec_files: failed_files)
+  end
+
+  def neutralizer(spec_files: [], spec_resolver: ->(_f) { "spec/foo_spec.rb" }, fallback_dir: "spec")
+    cfg = Evilution::Config.new(quiet: true, baseline: false, skip_config_file: true, spec_files: spec_files)
+    described_class.new(config: cfg, spec_resolver: spec_resolver, fallback_dir: fallback_dir)
+  end
+
+  it "returns the result unchanged when result is not survived" do
+    r = killed(mutation)
+    expect(neutralizer.call(r, baseline_result: baseline_failed)).to be(r)
+  end
+
+  it "returns the result unchanged when baseline_result is nil" do
+    r = survived(mutation)
+    expect(neutralizer.call(r, baseline_result: nil)).to be(r)
+  end
+
+  it "returns the result unchanged when baseline did not fail" do
+    r = survived(mutation)
+    baseline_ok = instance_double("BaselineResult", failed?: false)
+    expect(neutralizer.call(r, baseline_result: baseline_ok)).to be(r)
+  end
+
+  it "neutralizes survived results unconditionally when config.spec_files is non-empty" do
+    nz = neutralizer(spec_files: ["spec/foo_spec.rb"])
+    r = survived(mutation)
+    out = nz.call(r, baseline_result: baseline_failed)
+    expect(out.status).to eq(:neutral)
+  end
+
+  it "neutralizes when resolved spec_file is in baseline.failed_spec_files" do
+    resolver = ->(_f) { "spec/foo_spec.rb" }
+    nz = neutralizer(spec_resolver: resolver)
+    r = survived(mutation)
+    bl = baseline_failed(failed_files: ["spec/foo_spec.rb"])
+    expect(nz.call(r, baseline_result: bl).status).to eq(:neutral)
+  end
+
+  it "does NOT neutralize when resolved spec_file is not in baseline.failed_spec_files" do
+    resolver = ->(_f) { "spec/foo_spec.rb" }
+    nz = neutralizer(spec_resolver: resolver)
+    r = survived(mutation)
+    bl = baseline_failed(failed_files: ["spec/other_spec.rb"])
+    expect(nz.call(r, baseline_result: bl)).to be(r)
+  end
+
+  it "uses fallback_dir when spec_resolver returns nil" do
+    resolver = ->(_f) {}
+    nz = neutralizer(spec_resolver: resolver, fallback_dir: "spec")
+    r = survived(mutation)
+    bl = baseline_failed(failed_files: ["spec"])
+    expect(nz.call(r, baseline_result: bl).status).to eq(:neutral)
+  end
+end

--- a/spec/evilution/runner/mutation_executor/neutralizer/infra_error_spec.rb
+++ b/spec/evilution/runner/mutation_executor/neutralizer/infra_error_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "evilution/mutation"
+require "evilution/result/mutation_result"
+require "evilution/runner/mutation_executor/neutralizer/infra_error"
+
+RSpec.describe Evilution::Runner::MutationExecutor::Neutralizer::InfraError do
+  let(:neutralizer) { described_class.new }
+  let(:mutation) { instance_double(Evilution::Mutation, file_path: "lib/foo.rb") }
+
+  def result(status:, error_class: nil, error_message: nil, error_backtrace: nil)
+    Evilution::Result::MutationResult.new(
+      mutation: mutation, status: status, duration: 0.01,
+      error_class: error_class, error_message: error_message, error_backtrace: error_backtrace
+    )
+  end
+
+  it "returns the result unchanged when there is no error" do
+    r = result(status: :killed)
+    expect(neutralizer.call(r)).to be(r)
+  end
+
+  it "returns the result unchanged when error_class is not infra" do
+    r = result(status: :error, error_class: "RuntimeError", error_backtrace: ["spec/spec_helper.rb:1"])
+    expect(neutralizer.call(r)).to be(r)
+  end
+
+  it "returns the result unchanged when error origin is not infra (first frame is mutation code)" do
+    r = result(status: :error, error_class: "NameError", error_backtrace: ["lib/foo.rb:5", "spec/spec_helper.rb:1"])
+    expect(neutralizer.call(r)).to be(r)
+  end
+
+  it "neutralizes :error when error_class is infra and first frame matches infra path" do
+    r = result(status: :error, error_class: "LoadError", error_backtrace: ["spec/spec_helper.rb:1"])
+    out = neutralizer.call(r)
+    expect(out.status).to eq(:neutral)
+    expect(out.error_class).to eq("LoadError")
+  end
+
+  it "neutralizes :error when first frame matches rails_helper path" do
+    r = result(status: :error, error_class: "NameError", error_backtrace: ["spec/rails_helper.rb:3"])
+    expect(neutralizer.call(r).status).to eq(:neutral)
+  end
+
+  it "neutralizes :error when first frame matches spec/support/" do
+    r = result(status: :error, error_class: "LoadError", error_backtrace: ["spec/support/init.rb:1"])
+    expect(neutralizer.call(r).status).to eq(:neutral)
+  end
+
+  it "neutralizes :killed when error_class is in INFRA_CRASH_CLASSES (no backtrace check)" do
+    r = result(status: :killed, error_class: "Timeout::Error")
+    expect(neutralizer.call(r).status).to eq(:neutral)
+  end
+
+  it "neutralizes :killed for ActiveRecord timeout/lock crashes" do
+    %w[ActiveRecord::StatementTimeout ActiveRecord::Deadlocked ActiveRecord::ConnectionTimeoutError
+       ActiveRecord::LockWaitTimeout SQLite3::BusyException].each do |klass|
+      r = result(status: :killed, error_class: klass)
+      expect(neutralizer.call(r).status).to eq(:neutral), "expected #{klass} → :neutral"
+    end
+  end
+
+  it "does not neutralize :killed when error_class is NOT in crash list" do
+    r = result(status: :killed, error_class: "RuntimeError")
+    expect(neutralizer.call(r)).to be(r)
+  end
+end

--- a/spec/evilution/runner/mutation_executor/result_cache_spec.rb
+++ b/spec/evilution/runner/mutation_executor/result_cache_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "evilution/mutation"
+require "evilution/result/mutation_result"
+require "evilution/runner/mutation_executor/result_packer"
+require "evilution/runner/mutation_executor/result_cache"
+
+RSpec.describe Evilution::Runner::MutationExecutor::ResultCache do
+  def mutation(unparseable: false)
+    instance_double(Evilution::Mutation, file_path: "lib/foo.rb", unparseable?: unparseable)
+  end
+
+  def killed(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :killed, duration: 0.1, killing_test: "t", test_command: "c")
+  end
+
+  def survived(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :survived, duration: 0.1)
+  end
+
+  describe "#fetch" do
+    it "returns nil when the underlying cache is nil (no caching configured)" do
+      expect(described_class.new(nil).fetch(mutation)).to be_nil
+    end
+
+    it "returns nil when the cache has no entry for the mutation" do
+      backend = instance_double("Cache", fetch: nil)
+      expect(described_class.new(backend).fetch(mutation)).to be_nil
+    end
+
+    it "returns nil when the cached entry status is not killed or timeout" do
+      backend = instance_double("Cache", fetch: { status: :survived, duration: 0.1 })
+      expect(described_class.new(backend).fetch(mutation)).to be_nil
+    end
+
+    it "rebuilds a MutationResult when status is killed" do
+      mut = mutation
+      backend = instance_double("Cache", fetch: { status: :killed, duration: 0.2, killing_test: "t", test_command: "c" })
+      result = described_class.new(backend).fetch(mut)
+      expect(result.status).to eq(:killed)
+      expect(result.duration).to eq(0.2)
+      expect(result.mutation).to be(mut)
+    end
+
+    it "rebuilds a MutationResult when status is timeout" do
+      mut = mutation
+      backend = instance_double("Cache", fetch: { status: :timeout, duration: 5.0, killing_test: nil, test_command: "c" })
+      result = described_class.new(backend).fetch(mut)
+      expect(result.status).to eq(:timeout)
+    end
+  end
+
+  describe "#store" do
+    it "is a no-op when the underlying cache is nil" do
+      expect { described_class.new(nil).store(mutation, killed(mutation)) }.not_to raise_error
+    end
+
+    it "is a no-op for non-killed/timeout results" do
+      backend = instance_double("Cache")
+      expect(backend).not_to receive(:store)
+      described_class.new(backend).store(mutation, survived(mutation))
+    end
+
+    it "stores killed results with status/duration/killing_test/test_command" do
+      mut = mutation
+      backend = instance_double("Cache")
+      expect(backend).to receive(:store).with(mut,
+                                              status: :killed,
+                                              duration: 0.1,
+                                              killing_test: "t",
+                                              test_command: "c")
+      described_class.new(backend).store(mut, killed(mut))
+    end
+  end
+
+  describe "#partition" do
+    let(:packer) { Evilution::Runner::MutationExecutor::ResultPacker.new }
+
+    it "splits batch into uncached_indices and cached_results, encoding cached entries via packer" do
+      m1 = mutation                                 # uncached
+      m2 = mutation                                 # cache hit
+      m3 = mutation(unparseable: true)              # unparseable shortcut
+      backend = instance_double("Cache")
+      allow(backend).to receive(:fetch).with(m1).and_return(nil)
+      allow(backend).to receive(:fetch).with(m2).and_return(status: :killed, duration: 0.3, killing_test: "k", test_command: "c")
+
+      cache = described_class.new(backend)
+      uncached_indices, cached_results = cache.partition([m1, m2, m3], packer: packer)
+
+      expect(uncached_indices).to eq([0])
+      expect(cached_results.keys).to contain_exactly(1, 2)
+      expect(cached_results[1][:status]).to eq(:killed)
+      expect(cached_results[2][:status]).to eq(:unparseable)
+    end
+  end
+end

--- a/spec/evilution/runner/mutation_executor/result_notifier_spec.rb
+++ b/spec/evilution/runner/mutation_executor/result_notifier_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "evilution/config"
+require "evilution/result/mutation_result"
+require "evilution/runner/diagnostics"
+require "evilution/runner/mutation_executor/result_notifier"
+
+RSpec.describe Evilution::Runner::MutationExecutor::ResultNotifier do
+  def cfg(**overrides)
+    Evilution::Config.new(quiet: true, baseline: false, skip_config_file: true, **overrides)
+  end
+
+  def mutation
+    instance_double("Mutation")
+  end
+
+  def survived(mut = mutation)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :survived, duration: 0.01)
+  end
+
+  def killed(mut = mutation)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :killed, duration: 0.01)
+  end
+
+  def diagnostics
+    Evilution::Runner::Diagnostics.new(cfg)
+  end
+
+  it "calls on_result for each result" do
+    seen = []
+    nf = described_class.new(cfg, hooks: nil, diagnostics: diagnostics, on_result: ->(r) { seen << r.status })
+    nf.start(2)
+    nf.notify(killed, 1)
+    nf.notify(survived, 2)
+    nf.finish
+
+    expect(seen).to eq(%i[killed survived])
+  end
+
+  it "delegates progress and mutation diagnostics to diagnostics" do
+    diags = diagnostics
+    expect(diags).to receive(:log_progress).with(1, :killed)
+    expect(diags).to receive(:log_mutation_diagnostics).with(an_instance_of(Evilution::Result::MutationResult))
+
+    nf = described_class.new(cfg, hooks: nil, diagnostics: diags, on_result: nil)
+    nf.start(1)
+    nf.notify(killed, 1)
+    nf.finish
+  end
+
+  it "returns :continue when fail_fast is disabled" do
+    nf = described_class.new(cfg, hooks: nil, diagnostics: diagnostics, on_result: nil)
+    nf.start(3)
+    expect(nf.notify(survived, 1)).to eq(:continue)
+    expect(nf.notify(survived, 2)).to eq(:continue)
+  end
+
+  it "returns :truncate after survived_count >= config.fail_fast" do
+    nf = described_class.new(cfg(fail_fast: 2), hooks: nil, diagnostics: diagnostics, on_result: nil)
+    nf.start(5)
+    expect(nf.notify(survived, 1)).to eq(:continue)
+    expect(nf.notify(survived, 2)).to eq(:truncate)
+  end
+
+  it "does not count killed results toward survived" do
+    nf = described_class.new(cfg(fail_fast: 1), hooks: nil, diagnostics: diagnostics, on_result: nil)
+    nf.start(3)
+    expect(nf.notify(killed, 1)).to eq(:continue)
+    expect(nf.notify(killed, 2)).to eq(:continue)
+    expect(nf.notify(survived, 3)).to eq(:truncate)
+  end
+
+  it "is safe with on_result: nil (no error, returns control signal)" do
+    nf = described_class.new(cfg, hooks: nil, diagnostics: diagnostics, on_result: nil)
+    nf.start(1)
+    expect { nf.notify(killed, 1) }.not_to raise_error
+  end
+end

--- a/spec/evilution/runner/mutation_executor/result_notifier_spec.rb
+++ b/spec/evilution/runner/mutation_executor/result_notifier_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Evilution::Runner::MutationExecutor::ResultNotifier do
 
   it "calls on_result for each result" do
     seen = []
-    nf = described_class.new(cfg, hooks: nil, diagnostics: diagnostics, on_result: ->(r) { seen << r.status })
+    nf = described_class.new(cfg, diagnostics: diagnostics, on_result: ->(r) { seen << r.status })
     nf.start(2)
     nf.notify(killed, 1)
     nf.notify(survived, 2)
@@ -42,28 +42,28 @@ RSpec.describe Evilution::Runner::MutationExecutor::ResultNotifier do
     expect(diags).to receive(:log_progress).with(1, :killed)
     expect(diags).to receive(:log_mutation_diagnostics).with(an_instance_of(Evilution::Result::MutationResult))
 
-    nf = described_class.new(cfg, hooks: nil, diagnostics: diags, on_result: nil)
+    nf = described_class.new(cfg, diagnostics: diags, on_result: nil)
     nf.start(1)
     nf.notify(killed, 1)
     nf.finish
   end
 
   it "returns :continue when fail_fast is disabled" do
-    nf = described_class.new(cfg, hooks: nil, diagnostics: diagnostics, on_result: nil)
+    nf = described_class.new(cfg, diagnostics: diagnostics, on_result: nil)
     nf.start(3)
     expect(nf.notify(survived, 1)).to eq(:continue)
     expect(nf.notify(survived, 2)).to eq(:continue)
   end
 
   it "returns :truncate after survived_count >= config.fail_fast" do
-    nf = described_class.new(cfg(fail_fast: 2), hooks: nil, diagnostics: diagnostics, on_result: nil)
+    nf = described_class.new(cfg(fail_fast: 2), diagnostics: diagnostics, on_result: nil)
     nf.start(5)
     expect(nf.notify(survived, 1)).to eq(:continue)
     expect(nf.notify(survived, 2)).to eq(:truncate)
   end
 
   it "does not count killed results toward survived" do
-    nf = described_class.new(cfg(fail_fast: 1), hooks: nil, diagnostics: diagnostics, on_result: nil)
+    nf = described_class.new(cfg(fail_fast: 1), diagnostics: diagnostics, on_result: nil)
     nf.start(3)
     expect(nf.notify(killed, 1)).to eq(:continue)
     expect(nf.notify(killed, 2)).to eq(:continue)
@@ -71,7 +71,7 @@ RSpec.describe Evilution::Runner::MutationExecutor::ResultNotifier do
   end
 
   it "is safe with on_result: nil (no error, returns control signal)" do
-    nf = described_class.new(cfg, hooks: nil, diagnostics: diagnostics, on_result: nil)
+    nf = described_class.new(cfg, diagnostics: diagnostics, on_result: nil)
     nf.start(1)
     expect { nf.notify(killed, 1) }.not_to raise_error
   end

--- a/spec/evilution/runner/mutation_executor/result_packer_spec.rb
+++ b/spec/evilution/runner/mutation_executor/result_packer_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "evilution/mutation"
+require "evilution/result/mutation_result"
+require "evilution/runner/mutation_executor/result_packer"
+
+RSpec.describe Evilution::Runner::MutationExecutor::ResultPacker do
+  let(:packer) { described_class.new }
+
+  let(:mutation) { instance_double(Evilution::Mutation, file_path: "lib/foo.rb") }
+
+  let(:result) do
+    Evilution::Result::MutationResult.new(
+      mutation: mutation,
+      status: :killed,
+      duration: 0.5,
+      killing_test: "spec/foo_spec.rb:10",
+      test_command: "rspec spec/foo_spec.rb",
+      child_rss_kb: 1024,
+      memory_delta_kb: 256,
+      parent_rss_kb: 2048,
+      error_message: "msg",
+      error_class: "RuntimeError",
+      error_backtrace: ["a.rb:1"]
+    )
+  end
+
+  describe "#compact" do
+    it "extracts all transport-relevant fields into a Hash without the mutation" do
+      hash = packer.compact(result)
+
+      expect(hash).to eq(
+        status: :killed,
+        duration: 0.5,
+        killing_test: "spec/foo_spec.rb:10",
+        test_command: "rspec spec/foo_spec.rb",
+        child_rss_kb: 1024,
+        memory_delta_kb: 256,
+        parent_rss_kb: 2048,
+        error_message: "msg",
+        error_class: "RuntimeError",
+        error_backtrace: ["a.rb:1"]
+      )
+    end
+  end
+
+  describe "#rebuild" do
+    it "constructs a MutationResult from a packed Hash plus a mutation" do
+      hash = packer.compact(result)
+      rebuilt = packer.rebuild(mutation, hash)
+
+      expect(rebuilt.mutation).to be(mutation)
+      expect(rebuilt.status).to eq(:killed)
+      expect(rebuilt.duration).to eq(0.5)
+      expect(rebuilt.killing_test).to eq("spec/foo_spec.rb:10")
+      expect(rebuilt.error_class).to eq("RuntimeError")
+      expect(rebuilt.error_backtrace).to eq(["a.rb:1"])
+    end
+  end
+end

--- a/spec/evilution/runner/mutation_executor/strategy/parallel_spec.rb
+++ b/spec/evilution/runner/mutation_executor/strategy/parallel_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "evilution/config"
+require "evilution/mutation"
+require "evilution/result/mutation_result"
+require "evilution/runner/diagnostics"
+require "evilution/runner/mutation_executor/result_cache"
+require "evilution/runner/mutation_executor/result_packer"
+require "evilution/runner/mutation_executor/result_notifier"
+require "evilution/runner/mutation_executor/neutralization_pipeline"
+require "evilution/runner/mutation_executor/strategy/parallel"
+
+RSpec.describe Evilution::Runner::MutationExecutor::Strategy::Parallel do
+  let(:cfg) do
+    Evilution::Config.new(quiet: true, baseline: false, skip_config_file: true, jobs: 2, timeout: 30)
+  end
+
+  def mutation(id)
+    instance_double(Evilution::Mutation, file_path: "lib/foo.rb", to_s: id, unparseable?: false, strip_sources!: nil)
+  end
+
+  def killed(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :killed, duration: 0.1, killing_test: "t", test_command: "c")
+  end
+
+  def diagnostics
+    diags = Evilution::Runner::Diagnostics.new(cfg)
+    allow(diags).to receive(:log_memory)
+    allow(diags).to receive(:log_worker_stats)
+    allow(diags).to receive(:aggregate_worker_stats).and_return({})
+    diags
+  end
+
+  def notifier(diags = diagnostics)
+    Evilution::Runner::MutationExecutor::ResultNotifier.new(cfg, hooks: nil, diagnostics: diags, on_result: nil)
+  end
+
+  it "calls isolator inside the pool for uncached mutations and rebuilds via packer" do
+    m1 = mutation("m1")
+    m2 = mutation("m2")
+    backend = instance_double("Cache", fetch: nil)
+    allow(backend).to receive(:store)
+
+    isolator = double(:isolator)
+    allow(isolator).to receive(:call).and_return(killed(m1), killed(m2))
+
+    packer = Evilution::Runner::MutationExecutor::ResultPacker.new
+    pool = double(:pool)
+    allow(pool).to receive(:worker_stats).and_return([])
+    allow(pool).to receive(:map) { |uncached, &block| uncached.map(&block) }
+
+    strategy = described_class.new(
+      cache: Evilution::Runner::MutationExecutor::ResultCache.new(backend),
+      isolator: isolator,
+      packer: packer,
+      pipeline: Evilution::Runner::MutationExecutor::NeutralizationPipeline.new([]),
+      notifier: notifier,
+      pool_factory: -> { pool },
+      config: cfg
+    )
+
+    results, truncated = strategy.call([m1, m2], baseline_result: nil, integration: ->(_) { "cmd" })
+
+    expect(results.map(&:status)).to eq(%i[killed killed])
+    expect(truncated).to be false
+  end
+
+  it "uses cached results in place of pool execution and preserves batch order" do
+    m1 = mutation("m1")
+    m2 = mutation("m2")
+    backend = instance_double("Cache")
+    allow(backend).to receive(:fetch).with(m1).and_return(nil)
+    allow(backend).to receive(:fetch).with(m2).and_return(status: :killed, duration: 0.5, killing_test: "k", test_command: "c")
+    allow(backend).to receive(:store)
+
+    isolator = double(:isolator)
+    allow(isolator).to receive(:call).and_return(killed(m1))
+    pool = double(:pool, worker_stats: [])
+    allow(pool).to receive(:map) { |uncached, &block| uncached.map(&block) }
+
+    strategy = described_class.new(
+      cache: Evilution::Runner::MutationExecutor::ResultCache.new(backend),
+      isolator: isolator,
+      packer: Evilution::Runner::MutationExecutor::ResultPacker.new,
+      pipeline: Evilution::Runner::MutationExecutor::NeutralizationPipeline.new([]),
+      notifier: notifier,
+      pool_factory: -> { pool },
+      config: cfg
+    )
+
+    results, = strategy.call([m1, m2], baseline_result: nil, integration: ->(_) { "cmd" })
+
+    expect(results[0].status).to eq(:killed)
+    expect(results[0].duration).to eq(0.1)
+    expect(results[1].status).to eq(:killed)
+    expect(results[1].duration).to eq(0.5)
+  end
+
+  it "stops processing further batches when notifier signals :truncate" do
+    cfg_ff = Evilution::Config.new(quiet: true, baseline: false, skip_config_file: true, jobs: 1, fail_fast: 1)
+    m1 = mutation("m1")
+    m2 = mutation("m2")
+    backend = instance_double("Cache", fetch: nil)
+    allow(backend).to receive(:store)
+    isolator = double(:isolator)
+    allow(isolator).to receive(:call).and_return(
+      Evilution::Result::MutationResult.new(mutation: m1, status: :survived, duration: 0.01)
+    )
+    pool = double(:pool, worker_stats: [])
+    allow(pool).to receive(:map) { |uncached, &block| uncached.map(&block) }
+    diags = Evilution::Runner::Diagnostics.new(cfg_ff)
+    allow(diags).to receive(:log_memory)
+    allow(diags).to receive(:log_worker_stats)
+    allow(diags).to receive(:aggregate_worker_stats).and_return({})
+
+    strategy = described_class.new(
+      cache: Evilution::Runner::MutationExecutor::ResultCache.new(backend),
+      isolator: isolator,
+      packer: Evilution::Runner::MutationExecutor::ResultPacker.new,
+      pipeline: Evilution::Runner::MutationExecutor::NeutralizationPipeline.new([]),
+      notifier: Evilution::Runner::MutationExecutor::ResultNotifier.new(cfg_ff, hooks: nil, diagnostics: diags, on_result: nil),
+      pool_factory: -> { pool },
+      config: cfg_ff
+    )
+
+    results, truncated = strategy.call([m1, m2], baseline_result: nil, integration: ->(_) { "cmd" })
+
+    expect(results.length).to eq(1)
+    expect(truncated).to be true
+    expect(isolator).to have_received(:call).once
+  end
+
+  it "calls strip_sources! on every mutation in batch and logs memory after batch" do
+    m1 = mutation("m1")
+    expect(m1).to receive(:strip_sources!)
+
+    backend = instance_double("Cache", fetch: nil)
+    allow(backend).to receive(:store)
+    isolator = double(:isolator)
+    allow(isolator).to receive(:call).and_return(killed(m1))
+    pool = double(:pool, worker_stats: [])
+    allow(pool).to receive(:map) { |uncached, &block| uncached.map(&block) }
+    diags = diagnostics
+    expect(diags).to receive(:log_memory).with("after batch", an_instance_of(String))
+
+    strategy = described_class.new(
+      cache: Evilution::Runner::MutationExecutor::ResultCache.new(backend),
+      isolator: isolator,
+      packer: Evilution::Runner::MutationExecutor::ResultPacker.new,
+      pipeline: Evilution::Runner::MutationExecutor::NeutralizationPipeline.new([]),
+      notifier: notifier(diags),
+      pool_factory: -> { pool },
+      config: cfg,
+      diagnostics: diags
+    )
+
+    strategy.call([m1], baseline_result: nil, integration: ->(_) { "cmd" })
+  end
+end

--- a/spec/evilution/runner/mutation_executor/strategy/parallel_spec.rb
+++ b/spec/evilution/runner/mutation_executor/strategy/parallel_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Evilution::Runner::MutationExecutor::Strategy::Parallel do
   end
 
   def notifier(diags = diagnostics)
-    Evilution::Runner::MutationExecutor::ResultNotifier.new(cfg, hooks: nil, diagnostics: diags, on_result: nil)
+    Evilution::Runner::MutationExecutor::ResultNotifier.new(cfg, diagnostics: diags, on_result: nil)
   end
 
   it "calls isolator inside the pool for uncached mutations and rebuilds via packer" do
@@ -118,7 +118,7 @@ RSpec.describe Evilution::Runner::MutationExecutor::Strategy::Parallel do
       isolator: isolator,
       packer: Evilution::Runner::MutationExecutor::ResultPacker.new,
       pipeline: Evilution::Runner::MutationExecutor::NeutralizationPipeline.new([]),
-      notifier: Evilution::Runner::MutationExecutor::ResultNotifier.new(cfg_ff, hooks: nil, diagnostics: diags, on_result: nil),
+      notifier: Evilution::Runner::MutationExecutor::ResultNotifier.new(cfg_ff, diagnostics: diags, on_result: nil),
       pool_factory: -> { pool },
       config: cfg_ff
     )

--- a/spec/evilution/runner/mutation_executor/strategy/sequential_spec.rb
+++ b/spec/evilution/runner/mutation_executor/strategy/sequential_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "evilution/config"
+require "evilution/mutation"
+require "evilution/result/mutation_result"
+require "evilution/runner/diagnostics"
+require "evilution/runner/mutation_executor/result_cache"
+require "evilution/runner/mutation_executor/result_notifier"
+require "evilution/runner/mutation_executor/mutation_runner"
+require "evilution/runner/mutation_executor/neutralization_pipeline"
+require "evilution/runner/mutation_executor/strategy/sequential"
+
+RSpec.describe Evilution::Runner::MutationExecutor::Strategy::Sequential do
+  let(:cfg) { Evilution::Config.new(quiet: true, baseline: false, skip_config_file: true, timeout: 30) }
+
+  def mutation(id, file: "lib/foo.rb", unparseable: false)
+    instance_double(Evilution::Mutation, file_path: file, to_s: id, unparseable?: unparseable, strip_sources!: nil)
+  end
+
+  def killed(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :killed, duration: 0.01, test_command: "c")
+  end
+
+  def survived(mut)
+    Evilution::Result::MutationResult.new(mutation: mut, status: :survived, duration: 0.01)
+  end
+
+  def runner_returning(*results)
+    queue = results.dup
+    runner = double(:runner)
+    allow(runner).to receive(:call) { |_mut, **| queue.shift }
+    runner
+  end
+
+  def passthrough_pipeline
+    Evilution::Runner::MutationExecutor::NeutralizationPipeline.new([])
+  end
+
+  def notifier(config: cfg, on_result: nil)
+    Evilution::Runner::MutationExecutor::ResultNotifier.new(
+      config,
+      hooks: nil,
+      diagnostics: Evilution::Runner::Diagnostics.new(config),
+      on_result: on_result
+    )
+  end
+
+  it "iterates mutations, calls strip_sources! per mutation, and returns [results, false]" do
+    m1 = mutation("m1")
+    m2 = mutation("m2")
+    expect(m1).to receive(:strip_sources!)
+    expect(m2).to receive(:strip_sources!)
+
+    strategy = described_class.new(
+      runner: runner_returning(killed(m1), killed(m2)),
+      pipeline: passthrough_pipeline,
+      notifier: notifier
+    )
+
+    integration = ->(_) { "cmd" }
+    results, truncated = strategy.call([m1, m2], baseline_result: nil, integration: integration)
+
+    expect(results.map(&:status)).to eq(%i[killed killed])
+    expect(truncated).to be false
+  end
+
+  it "stops early and returns truncated=true when notifier signals :truncate" do
+    m1 = mutation("m1")
+    m2 = mutation("m2")
+    m3 = mutation("m3")
+
+    strategy = described_class.new(
+      runner: runner_returning(survived(m1), survived(m2), survived(m3)),
+      pipeline: passthrough_pipeline,
+      notifier: notifier(config: Evilution::Config.new(quiet: true, baseline: false, skip_config_file: true, fail_fast: 2))
+    )
+
+    results, truncated = strategy.call([m1, m2, m3], baseline_result: nil, integration: ->(_) { "cmd" })
+
+    expect(results.length).to eq(2)
+    expect(truncated).to be true
+  end
+
+  it "applies the pipeline to each result" do
+    m1 = mutation("m1")
+    nz = double(:neutralizer)
+    allow(nz).to receive(:call).and_return(killed(m1))
+    pipeline = Evilution::Runner::MutationExecutor::NeutralizationPipeline.new([nz])
+
+    strategy = described_class.new(
+      runner: runner_returning(survived(m1)),
+      pipeline: pipeline,
+      notifier: notifier
+    )
+
+    results, = strategy.call([m1], baseline_result: :baseline, integration: ->(_) { "cmd" })
+
+    expect(results.first.status).to eq(:killed)
+    expect(nz).to have_received(:call).with(an_instance_of(Evilution::Result::MutationResult), baseline_result: :baseline)
+  end
+end

--- a/spec/evilution/runner/mutation_executor/strategy/sequential_spec.rb
+++ b/spec/evilution/runner/mutation_executor/strategy/sequential_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe Evilution::Runner::MutationExecutor::Strategy::Sequential do
   def notifier(config: cfg, on_result: nil)
     Evilution::Runner::MutationExecutor::ResultNotifier.new(
       config,
-      hooks: nil,
       diagnostics: Evilution::Runner::Diagnostics.new(config),
       on_result: on_result
     )

--- a/spec/evilution/runner/mutation_executor_spec.rb
+++ b/spec/evilution/runner/mutation_executor_spec.rb
@@ -5,6 +5,16 @@ require "evilution/runner/mutation_executor"
 require "evilution/runner/diagnostics"
 require "evilution/runner/baseline_runner"
 
+# Coordinator-level smoke tests. Detailed behavior of collaborators is covered by:
+#   spec/evilution/runner/mutation_executor/result_cache_spec.rb
+#   spec/evilution/runner/mutation_executor/result_packer_spec.rb
+#   spec/evilution/runner/mutation_executor/result_notifier_spec.rb
+#   spec/evilution/runner/mutation_executor/mutation_runner_spec.rb
+#   spec/evilution/runner/mutation_executor/neutralization_pipeline_spec.rb
+#   spec/evilution/runner/mutation_executor/neutralizer/infra_error_spec.rb
+#   spec/evilution/runner/mutation_executor/neutralizer/baseline_failed_spec.rb
+#   spec/evilution/runner/mutation_executor/strategy/sequential_spec.rb
+#   spec/evilution/runner/mutation_executor/strategy/parallel_spec.rb
 RSpec.describe Evilution::Runner::MutationExecutor do
   def config(**overrides)
     Evilution::Config.new(quiet: true, baseline: false, skip_config_file: true, **overrides)
@@ -52,39 +62,44 @@ RSpec.describe Evilution::Runner::MutationExecutor do
     )
   end
 
-  def killed_crash_result(mutation, error_class:, error_message: "test crashes", error_backtrace: [])
-    Evilution::Result::MutationResult.new(
-      mutation: mutation, status: :killed, duration: 0.01,
-      error_class: error_class, error_message: error_message, error_backtrace: error_backtrace
-    )
-  end
-
   describe "#call" do
-    it "runs mutations sequentially when config.jobs is 1 and returns results + truncated flag" do
+    it "returns [results, truncated] tuple in sequential mode (jobs == 1)" do
       cfg = config(jobs: 1)
       mutations = [mutation, mutation]
       isolator = instance_double(Evilution::Isolation::Fork)
       allow(isolator).to receive(:call) { |mutation:, **| killed_result(mutation) }
 
-      executor = build(cfg, isolator: isolator)
-      results, truncated = executor.call(mutations, nil)
+      results, truncated = build(cfg, isolator: isolator).call(mutations, nil)
 
       expect(results.length).to eq(2)
       expect(results).to all(be_killed)
       expect(truncated).to be(false)
     end
 
-    it "stops early when fail_fast is reached" do
-      cfg = config(jobs: 1, fail_fast: 1)
-      mutations = [mutation, mutation, mutation]
+    it "dispatches to the parallel strategy when jobs > 1" do
+      cfg = config(jobs: 2)
+      mutations = [mutation, mutation]
       isolator = instance_double(Evilution::Isolation::Fork)
-      allow(isolator).to receive(:call) { |mutation:, **| survived_result(mutation) }
+      allow(isolator).to receive(:call) { |mutation:, **| killed_result(mutation) }
 
-      executor = build(cfg, isolator: isolator)
-      results, truncated = executor.call(mutations, nil)
+      parallel_strategy = instance_double(Evilution::Runner::MutationExecutor::Strategy::Parallel)
+      allow(parallel_strategy).to receive(:call).and_return([[], false])
+      expect(Evilution::Runner::MutationExecutor::Strategy::Parallel).to receive(:new).and_return(parallel_strategy)
 
-      expect(truncated).to be(true)
-      expect(results.length).to eq(1)
+      build(cfg, isolator: isolator).call(mutations, nil)
+    end
+
+    it "dispatches to the sequential strategy when jobs == 1" do
+      cfg = config(jobs: 1)
+      mutations = [mutation]
+      isolator = instance_double(Evilution::Isolation::Fork)
+      allow(isolator).to receive(:call) { |mutation:, **| killed_result(mutation) }
+
+      sequential_strategy = instance_double(Evilution::Runner::MutationExecutor::Strategy::Sequential)
+      allow(sequential_strategy).to receive(:call).and_return([[], false])
+      expect(Evilution::Runner::MutationExecutor::Strategy::Sequential).to receive(:new).and_return(sequential_strategy)
+
+      build(cfg, isolator: isolator).call(mutations, nil)
     end
 
     it "invokes on_result for each mutation result" do
@@ -94,327 +109,52 @@ RSpec.describe Evilution::Runner::MutationExecutor do
       allow(isolator).to receive(:call) { |mutation:, **| killed_result(mutation) }
       captured = []
 
-      executor = build(cfg, isolator: isolator, on_result: ->(r) { captured << r })
-      executor.call(mutations, nil)
+      build(cfg, isolator: isolator, on_result: ->(r) { captured << r }).call(mutations, nil)
 
       expect(captured.length).to eq(2)
     end
 
-    it "strips mutation sources after executing each result" do
-      cfg = config(jobs: 1)
-      m = mutation
-      isolator = instance_double(Evilution::Isolation::Fork)
-      allow(isolator).to receive(:call).and_return(killed_result(m))
-      expect(m).to receive(:strip_sources!)
-
-      build(cfg, isolator: isolator).call([m], nil)
-    end
-
-    it "short-circuits unparseable mutations in sequential path without invoking isolator" do
+    it "short-circuits unparseable mutations in sequential mode without invoking isolator" do
       cfg = config(jobs: 1)
       parseable = mutation
       unparseable = mutation(unparseable: true)
       isolator = instance_double(Evilution::Isolation::Fork)
       allow(isolator).to receive(:call) { |mutation:, **| killed_result(mutation) }
 
-      executor = build(cfg, isolator: isolator)
-      results, = executor.call([parseable, unparseable], nil)
+      results, = build(cfg, isolator: isolator).call([parseable, unparseable], nil)
 
       expect(isolator).to have_received(:call).once
       expect(results.map(&:status)).to eq(%i[killed unparseable])
     end
 
-    it "short-circuits unparseable mutations in parallel path without dispatching to pool" do
+    it "short-circuits unparseable mutations in parallel mode without dispatching to pool" do
       cfg = config(jobs: 2)
       mutations = [mutation(unparseable: true), mutation(unparseable: true)]
       isolator = instance_double(Evilution::Isolation::Fork)
 
-      executor = build(cfg, isolator: isolator)
-      results, = executor.call(mutations, nil)
+      results, = build(cfg, isolator: isolator).call(mutations, nil)
 
       expect(results.map(&:status)).to eq(%i[unparseable unparseable])
     end
 
-    it "neutralizes survivors when baseline is failed for the spec file" do
+    it "wires up the neutralization pipeline (infra-error + baseline-failed mixed batch)" do
       cfg = config(jobs: 1)
-      m = mutation(file: "lib/foo.rb")
+      infra_mut = mutation(file: "lib/foo.rb")
+      baseline_mut = mutation(file: "lib/foo.rb")
       isolator = instance_double(Evilution::Isolation::Fork)
-      allow(isolator).to receive(:call).and_return(survived_result(m))
+      allow(isolator).to receive(:call) do |mutation:, **|
+        if mutation.equal?(infra_mut)
+          error_result(infra_mut, error_class: "LoadError",
+                                  error_backtrace: ["spec/spec_helper.rb:3:in `require'"])
+        else
+          survived_result(baseline_mut)
+        end
+      end
       baseline = instance_double(Evilution::Baseline::Result, failed?: true, failed_spec_files: ["spec"])
 
-      executor = build(cfg, isolator: isolator)
-      results, = executor.call([m], baseline)
+      results, = build(cfg, isolator: isolator).call([infra_mut, baseline_mut], baseline)
 
-      expect(results.first.status).to eq(:neutral)
-    end
-
-    describe "infra-error neutralization" do
-      it "neutralizes :error LoadError when origin frame is spec_helper" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "LoadError",
-                          error_message: "cannot load such file -- missing_gem",
-                          error_backtrace: ["spec/spec_helper.rb:3:in `require'"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "keeps :error LoadError when origin frame is lib/ (mutation dynamic require)" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "LoadError",
-                          error_backtrace: ["lib/foo.rb:5:in `require'"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:error)
-      end
-
-      it "neutralizes :error NameError when origin frame is spec_helper" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "NameError",
-                          error_backtrace: ["spec/spec_helper.rb:15:in `<top (required)>'"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "neutralizes :error NameError when origin frame is rails_helper" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "NameError",
-                          error_backtrace: ["spec/rails_helper.rb:8:in `block'"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "neutralizes :error NameError when origin frame is spec/support" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "NameError",
-                          error_backtrace: ["spec/support/fixture_helpers.rb:42:in `let_it_be'"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "keeps :error NameError with lib/ origin as error (mutation-caused)" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "NameError",
-                          error_backtrace: ["lib/foo.rb:10:in `bar'", "lib/foo.rb:20:in `baz'"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:error)
-      end
-
-      # Regression for Copilot #795: an `any?` backtrace match would wrongly
-      # neutralize this case — mutation-caused error in lib/ with spec_helper
-      # frames deeper in the stack (typical when the helper required the file).
-      it "keeps :error as error when origin is lib/ even if spec_helper appears later in backtrace" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "NameError",
-                          error_backtrace: ["lib/foo.rb:10:in `bar'",
-                                            "spec/spec_helper.rb:3:in `require'",
-                                            "spec/foo_spec.rb:5:in `block'"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:error)
-      end
-
-      it "keeps :error with empty backtrace as error (no origin signal)" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "LoadError", error_backtrace: [])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:error)
-      end
-
-      it "keeps :error ArgumentError as error (not in infra allowlist)" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          error_result(m, error_class: "ArgumentError",
-                          error_backtrace: ["spec/spec_helper.rb:1:in `<top>'"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:error)
-      end
-
-      it "does not affect non-error statuses" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(killed_result(m))
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:killed)
-      end
-    end
-
-    # Regression for EV-toid / GH #814:
-    # parallel workers sharing a sqlite3 file produce ActiveRecord::StatementTimeout
-    # (and similar infra-flavored exceptions). CrashDetector reports them as crashes,
-    # fork isolator classifies as :killed. These are infra noise, not real kills, and
-    # must be demoted to :neutral so score reflects real mutation detection only.
-    describe "infra-crash neutralization" do
-      it "demotes :killed ActiveRecord::StatementTimeout to :neutral (no backtrace requirement)" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          killed_crash_result(m, error_class: "ActiveRecord::StatementTimeout",
-                                 error_message: "test crashes: ActiveRecord::StatementTimeout (10 crashes)",
-                                 error_backtrace: ["/gems/activerecord/lib/active_record/connection_adapters/sqlite3.rb:123"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "demotes :killed Timeout::Error to :neutral" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          killed_crash_result(m, error_class: "Timeout::Error",
-                                 error_backtrace: ["/gems/foo.rb:1"])
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "demotes :killed ActiveRecord::Deadlocked to :neutral" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          killed_crash_result(m, error_class: "ActiveRecord::Deadlocked")
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "demotes :killed ActiveRecord::ConnectionTimeoutError to :neutral" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          killed_crash_result(m, error_class: "ActiveRecord::ConnectionTimeoutError")
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "demotes :killed ActiveRecord::LockWaitTimeout to :neutral" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          killed_crash_result(m, error_class: "ActiveRecord::LockWaitTimeout")
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "demotes :killed SQLite3::BusyException to :neutral" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          killed_crash_result(m, error_class: "SQLite3::BusyException")
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:neutral)
-      end
-
-      it "keeps :killed with NoMethodError (genuine mutation-caused crash)" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          killed_crash_result(m, error_class: "NoMethodError")
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:killed)
-      end
-
-      it "keeps :killed with RuntimeError (not in infra allowlist)" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(
-          killed_crash_result(m, error_class: "RuntimeError")
-        )
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:killed)
-      end
-
-      it "keeps :killed with nil error_class (non-crash kill: assertion failure)" do
-        cfg = config(jobs: 1)
-        m = mutation
-        isolator = instance_double(Evilution::Isolation::Fork)
-        allow(isolator).to receive(:call).and_return(killed_result(m))
-
-        results, = build(cfg, isolator: isolator).call([m], nil)
-
-        expect(results.first.status).to eq(:killed)
-      end
+      expect(results.map(&:status)).to eq(%i[neutral neutral])
     end
   end
 end

--- a/spec/evilution/runner_isolation_spec.rb
+++ b/spec/evilution/runner_isolation_spec.rb
@@ -139,14 +139,6 @@ RSpec.describe Evilution::Runner, "isolation resolution" do
     end
   end
 
-  describe "parallel mode" do
-    it "uses isolator for worker isolation, not hardcoded InProcess" do
-      write_plain_target
-      config = build_config(isolation: :fork, jobs: 2)
-      runner = described_class.new(config: config)
-
-      expect(runner).to receive(:isolator).at_least(:once).and_call_original
-      runner.send(:mutation_executor).send(:run_parallel, [], nil)
-    end
-  end
+  # parallel mode isolator wiring covered by:
+  # spec/evilution/runner/mutation_executor/strategy/parallel_spec.rb
 end


### PR DESCRIPTION
- Introduced specs for the InfraError neutralizer to handle various error scenarios.
- Added tests for ResultCache to ensure proper fetching and storing of mutation results.
- Implemented ResultNotifier tests to verify result handling and diagnostics logging.
- Created ResultPacker tests for packing and rebuilding mutation results.
- Developed parallel and sequential strategy tests to validate mutation execution behavior.
- Updated the main mutation executor spec to reflect changes in strategy dispatching and error handling.
- Removed redundant parallel mode isolation tests, as they are now covered by dedicated strategy specs.