### PR TITLE
1007: Refactor collect_all_params at lib/evilution/mutator/operator/keyword_argument.rb

### DIFF
--- a/lib/evilution/mutator/operator/keyword_argument.rb
+++ b/lib/evilution/mutator/operator/keyword_argument.rb
@@ -83,14 +83,14 @@ class Evilution::Mutator::Operator::KeywordArgument < Evilution::Mutator::Base
   end
 
   def collect_all_params(params)
-    result = []
-    result.concat(params.requireds)
-    result.concat(params.optionals)
-    result << params.rest if params.rest
-    result.concat(params.posts)
-    result.concat(params.keywords)
-    result << params.keyword_rest if params.keyword_rest
-    result << params.block if params.block
-    result
+    [
+      *params.requireds,
+      *params.optionals,
+      params.rest,
+      *params.posts,
+      *params.keywords,
+      params.keyword_rest,
+      params.block
+    ].compact
   end
 end


### PR DESCRIPTION
## Summary
- Replace mutating `result = []` + concat/`<<` with single splat-and-compact expression in `collect_all_params`
- Drops ABC complexity below threshold (was 17.29) while preserving collection order

Closes #1007. Sub-issue of #371.

## Test plan
- [x] `bundle exec rubocop lib/evilution/mutator/operator/keyword_argument.rb` — clean
- [x] `bundle exec rspec spec/evilution/mutator/operator/keyword_argument_spec.rb` — 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)