### PR TITLE
1009: Refactor mutate_target_removal at lib/evilution/mutator/operator/multiple_assignment.rb

### DIFF
--- a/lib/evilution/mutator/operator/multiple_assignment.rb
+++ b/lib/evilution/mutator/operator/multiple_assignment.rb
@@ -18,19 +18,18 @@ class Evilution::Mutator::Operator::MultipleAssignment < Evilution::Mutator::Bas
   private
 
   def mutate_target_removal(node, lefts, values)
-    lefts.each_index do |i|
-      remaining_lefts = lefts.each_with_index.filter_map { |l, j| l.slice if j != i }
-      remaining_values = values.each_with_index.filter_map { |v, j| v.slice if j != i }
+    lefts.each_index { |i| emit_target_removal_at(node, lefts, values, i) }
+  end
 
-      replacement = "#{remaining_lefts.join(", ")} = #{remaining_values.join(", ")}"
-
-      add_mutation(
-        offset: node.location.start_offset,
-        length: node.location.length,
-        replacement: replacement,
-        node: node
-      )
-    end
+  def emit_target_removal_at(node, lefts, values, i)
+    remaining_lefts = lefts.each_with_index.filter_map { |l, j| l.slice if j != i }
+    remaining_values = values.each_with_index.filter_map { |v, j| v.slice if j != i }
+    add_mutation(
+      offset: node.location.start_offset,
+      length: node.location.length,
+      replacement: "#{remaining_lefts.join(", ")} = #{remaining_values.join(", ")}",
+      node: node
+    )
   end
 
   def mutate_swap(node, lefts, values)


### PR DESCRIPTION
## Summary
- Extract `emit_target_removal_at(node, lefts, values, i)` from the each-index loop body
- Drops ABC complexity below threshold (was 17.58)

Closes #1009. Sub-issue of #371.

## Test plan
- [x] `bundle exec rubocop lib/evilution/mutator/operator/multiple_assignment.rb` — clean
- [x] `bundle exec rspec spec/evilution/mutator/operator/multiple_assignment_spec.rb` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)