### PR TITLE
977: Refactor perform at lib/evilution/cli/commands/session_diff.rb

### DIFF
--- a/lib/evilution/cli/commands/session_diff.rb
+++ b/lib/evilution/cli/commands/session_diff.rb
@@ -14,16 +14,18 @@ class Evilution::CLI::Commands::SessionDiff < Evilution::CLI::Command
   def perform
     raise Evilution::ConfigError, "two session file paths required" unless @files.length == 2
 
-    store = Evilution::Session::Store.new
-    base_data = store.load(@files[0])
-    head_data = store.load(@files[1])
-    result = Evilution::Session::Diff.new.call(base_data, head_data)
+    result = compute_diff(@files)
     Evilution::CLI::Printers::SessionDiff.new(result, format: @options[:format]).render(@stdout)
     0
   rescue ::JSON::ParserError => e
     raise Evilution::Error, "invalid session file: #{e.message}"
   rescue SystemCallError => e
     raise Evilution::Error, e.message
+  end
+
+  def compute_diff(files)
+    store = Evilution::Session::Store.new
+    Evilution::Session::Diff.new.call(store.load(files[0]), store.load(files[1]))
   end
 end
 


### PR DESCRIPTION
## Summary
- Extract `compute_diff(files)` from `perform`
- Drops ABC complexity below threshold (was 17.35)

Closes #977. Sub-issue of #371.

## Test plan
- [x] `bundle exec rubocop lib/evilution/cli/commands/session_diff.rb` — clean
- [x] `bundle exec rspec spec/evilution/cli/commands/session_diff_spec.rb` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)