### PR TITLE
981: Refactor settings_lines at lib/evilution/cli/printers/environment.rb

### DIFF
--- a/lib/evilution/cli/printers/environment.rb
+++ b/lib/evilution/cli/printers/environment.rb
@@ -3,6 +3,12 @@
 require_relative "../printers"
 
 class Evilution::CLI::Printers::Environment
+  PLAIN_SETTINGS = %i[
+    timeout format integration jobs isolation baseline incremental
+    verbose quiet progress min_score suggest_tests save_session
+    skip_heredoc_literals
+  ].freeze
+
   def initialize(config, config_file:)
     @config = config
     @config_file = config_file
@@ -30,24 +36,18 @@ class Evilution::CLI::Printers::Environment
   end
 
   def settings_lines
-    [
-      "  timeout: #{@config.timeout}",
-      "  format: #{@config.format}",
-      "  integration: #{@config.integration}",
-      "  jobs: #{@config.jobs}",
-      "  isolation: #{@config.isolation}",
-      "  baseline: #{@config.baseline}",
-      "  incremental: #{@config.incremental}",
-      "  verbose: #{@config.verbose}",
-      "  quiet: #{@config.quiet}",
-      "  progress: #{@config.progress}",
-      "  fail_fast: #{@config.fail_fast || "(disabled)"}",
-      "  min_score: #{@config.min_score}",
-      "  suggest_tests: #{@config.suggest_tests}",
-      "  save_session: #{@config.save_session}",
-      "  target: #{@config.target || "(all files)"}",
-      "  skip_heredoc_literals: #{@config.skip_heredoc_literals}",
-      "  ignore_patterns: #{@config.ignore_patterns.empty? ? "(none)" : @config.ignore_patterns.inspect}"
-    ]
+    plain_lines = PLAIN_SETTINGS.map { |k| setting_line(k, @config.public_send(k)) }
+    plain_lines.insert(10, setting_line(:fail_fast, @config.fail_fast || "(disabled)"))
+    plain_lines.insert(14, setting_line(:target, @config.target || "(all files)"))
+    plain_lines << setting_line(:ignore_patterns, format_ignore_patterns(@config.ignore_patterns))
+    plain_lines
+  end
+
+  def setting_line(key, value)
+    "  #{key}: #{value}"
+  end
+
+  def format_ignore_patterns(patterns)
+    patterns.empty? ? "(none)" : patterns.inspect
   end
 end


### PR DESCRIPTION
## Summary
- Replace 17 inline `#{@config.X}` interpolations with iteration over `PLAIN_SETTINGS` constant
- Three special-case lines (fail_fast, target, ignore_patterns) inserted at fixed positions to preserve output order
- Extract `setting_line` and `format_ignore_patterns` helpers
- Drops `Metrics/AbcSize` below threshold

Closes #981

🤖 Generated with [Claude Code](https://claude.com/claude-code)