### PR TITLE
951: Replace CLI command tuple returns with named Data objects

### DIFF
--- a/lib/evilution/cli/commands/subjects.rb
+++ b/lib/evilution/cli/commands/subjects.rb
@@ -9,6 +9,9 @@ require_relative "../../runner"
 require_relative "../../mutator"
 
 class Evilution::CLI::Commands::Subjects < Evilution::CLI::Command
+  EntriesResult = Data.define(:entries, :total)
+  private_constant :EntriesResult
+
   private
 
   def perform
@@ -23,8 +26,8 @@ class Evilution::CLI::Commands::Subjects < Evilution::CLI::Command
       return 0
     end
 
-    entries, total = collect_entries(subjects, config)
-    Evilution::CLI::Printers::Subjects.new(entries, total_mutations: total).render(@stdout)
+    result = collect_entries(subjects, config)
+    Evilution::CLI::Printers::Subjects.new(result.entries, total_mutations: result.total).render(@stdout)
     0
   end
 
@@ -43,7 +46,7 @@ class Evilution::CLI::Commands::Subjects < Evilution::CLI::Command
       subj.release_node!
     end
 
-    [entries, total]
+    EntriesResult.new(entries: entries, total: total)
   end
 end
 

--- a/lib/evilution/cli/commands/util_mutation.rb
+++ b/lib/evilution/cli/commands/util_mutation.rb
@@ -11,11 +11,14 @@ require_relative "../../mutator/registry"
 require_relative "../../ast/parser"
 
 class Evilution::CLI::Commands::UtilMutation < Evilution::CLI::Command
+  SourceInput = Data.define(:source, :file_path)
+  private_constant :SourceInput
+
   private
 
   def perform
-    source, file_path = resolve_util_mutation_source
-    subjects = parse_source_to_subjects(source, file_path)
+    input = resolve_util_mutation_source
+    subjects = parse_source_to_subjects(input.source, input.file_path)
     config = Evilution::Config.new(**@options)
     registry = Evilution::Mutator::Registry.default
     operator_options = build_operator_options(config)
@@ -38,13 +41,13 @@ class Evilution::CLI::Commands::UtilMutation < Evilution::CLI::Command
       tmpfile.write(@options[:eval])
       tmpfile.flush
       @util_tmpfile = tmpfile
-      [@options[:eval], tmpfile.path]
+      SourceInput.new(source: @options[:eval], file_path: tmpfile.path)
     elsif @files.first
       path = @files.first
       raise Evilution::Error, "file not found: #{path}" unless File.exist?(path)
 
       begin
-        [File.read(path), path]
+        SourceInput.new(source: File.read(path), file_path: path)
       rescue SystemCallError => e
         raise Evilution::Error, e.message
       end

--- a/lib/evilution/mcp/info_tool/actions/tests.rb
+++ b/lib/evilution/mcp/info_tool/actions/tests.rb
@@ -6,6 +6,9 @@ require_relative "../../../runner"
 require_relative "../../../spec_resolver"
 
 class Evilution::MCP::InfoTool::Actions::Tests < Evilution::MCP::InfoTool::Actions::Base
+  ResolveResult = Data.define(:resolved, :unresolved)
+  private_constant :ResolveResult
+
   def self.call(files: nil, spec: nil, integration: nil, skip_config: nil, **)
     return config_error("files is required") if files.nil? || files.empty?
 
@@ -25,12 +28,12 @@ class Evilution::MCP::InfoTool::Actions::Tests < Evilution::MCP::InfoTool::Actio
     end
 
     def resolved_specs_response(files, resolver)
-      resolved, unresolved = resolve_specs(files, resolver)
+      result = resolve_specs(files, resolver)
       success(
-        "specs" => resolved,
-        "unresolved" => unresolved,
+        "specs" => result.resolved,
+        "unresolved" => result.unresolved,
         "total_sources" => files.length,
-        "total_specs" => resolved.map { |r| r["spec"] }.uniq.length
+        "total_specs" => result.resolved.map { |r| r["spec"] }.uniq.length
       )
     end
 
@@ -61,7 +64,7 @@ class Evilution::MCP::InfoTool::Actions::Tests < Evilution::MCP::InfoTool::Actio
           unresolved << source
         end
       end
-      [resolved, unresolved]
+      ResolveResult.new(resolved: resolved, unresolved: unresolved)
     end
   end
 end


### PR DESCRIPTION
## Summary
- `CLI::Commands::Subjects#collect_entries` → returns `EntriesResult = Data.define(:entries, :total)`
- `CLI::Commands::UtilMutation#resolve_util_mutation_source` → returns `SourceInput = Data.define(:source, :file_path)`
- `MCP::InfoTool::Actions::Tests#resolve_specs` → returns `ResolveResult = Data.define(:resolved, :unresolved)`
- Each Data class is `private_constant` to its containing class

Closes #951

🤖 Generated with [Claude Code](https://claude.com/claude-code)