### PR TITLE
953: Replace ResultCache#partition tuple return with Partition Data

### DIFF
--- a/lib/evilution/runner/mutation_executor/result_cache.rb
+++ b/lib/evilution/runner/mutation_executor/result_cache.rb
@@ -7,6 +7,8 @@ class Evilution::Runner::MutationExecutor::ResultCache
   CACHEABLE_STATUSES = %i[killed timeout].freeze
   private_constant :CACHEABLE_STATUSES
 
+  Partition = Data.define(:uncached_indices, :cached_results)
+
   def initialize(backend)
     @backend = backend
   end
@@ -56,7 +58,7 @@ class Evilution::Runner::MutationExecutor::ResultCache
       end
     end
 
-    [uncached_indices, cached_results]
+    Partition.new(uncached_indices: uncached_indices, cached_results: cached_results)
   end
 
   private

--- a/lib/evilution/runner/mutation_executor/strategy/parallel.rb
+++ b/lib/evilution/runner/mutation_executor/strategy/parallel.rb
@@ -36,11 +36,11 @@ class Evilution::Runner::MutationExecutor::Strategy::Parallel
   private
 
   def run_batch(batch, pool, integration)
-    uncached_indices, cached_results = @cache.partition(batch, packer: @packer)
-    worker_results = run_uncached(batch, uncached_indices, pool, integration)
-    compact_results = merge(batch, uncached_indices, cached_results, worker_results)
+    partition = @cache.partition(batch, packer: @packer)
+    worker_results = run_uncached(batch, partition.uncached_indices, pool, integration)
+    compact_results = merge(batch, partition.uncached_indices, partition.cached_results, worker_results)
     batch_results = batch.zip(compact_results).map { |m, h| @packer.rebuild(m, h) }
-    uncached_indices.each { |i| @cache.store(batch_results[i].mutation, batch_results[i]) }
+    partition.uncached_indices.each { |i| @cache.store(batch_results[i].mutation, batch_results[i]) }
     batch.each(&:strip_sources!)
     batch_results
   end

--- a/spec/evilution/runner/mutation_executor/result_cache_spec.rb
+++ b/spec/evilution/runner/mutation_executor/result_cache_spec.rb
@@ -85,12 +85,12 @@ RSpec.describe Evilution::Runner::MutationExecutor::ResultCache do
       allow(backend).to receive(:fetch).with(m2).and_return(status: :killed, duration: 0.3, killing_test: "k", test_command: "c")
 
       cache = described_class.new(backend)
-      uncached_indices, cached_results = cache.partition([m1, m2, m3], packer: packer)
+      partition = cache.partition([m1, m2, m3], packer: packer)
 
-      expect(uncached_indices).to eq([0])
-      expect(cached_results.keys).to contain_exactly(1, 2)
-      expect(cached_results[1][:status]).to eq(:killed)
-      expect(cached_results[2][:status]).to eq(:unparseable)
+      expect(partition.uncached_indices).to eq([0])
+      expect(partition.cached_results.keys).to contain_exactly(1, 2)
+      expect(partition.cached_results[1][:status]).to eq(:killed)
+      expect(partition.cached_results[2][:status]).to eq(:unparseable)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Define `ResultCache::Partition = Data.define(:uncached_indices, :cached_results)`
- `ResultCache#partition` returns `Partition` instead of `[uncached_indices, cached_results]`
- `Strategy::Parallel#run_batch` consumes via `partition.uncached_indices` / `partition.cached_results`
- Cache spec updated to match

Closes #953

🤖 Generated with [Claude Code](https://claude.com/claude-code)