### PR TITLE
954: Replace WorkQueue tuple returns with named Data objects

### DIFF
--- a/lib/evilution/parallel/work_queue.rb
+++ b/lib/evilution/parallel/work_queue.rb
@@ -31,10 +31,11 @@ class Evilution::Parallel::WorkQueue
 
     retired = []
     begin
-      results, retired = dispatcher.run
+      run_result = dispatcher.run
+      retired = run_result.retired
       raise dispatcher.first_error if dispatcher.first_error
 
-      results
+      run_result.results
     ensure
       cleanup_workers(workers, retired)
     end

--- a/lib/evilution/parallel/work_queue/dispatcher.rb
+++ b/lib/evilution/parallel/work_queue/dispatcher.rb
@@ -4,6 +4,8 @@ require_relative "../work_queue"
 require_relative "collection_state"
 
 class Evilution::Parallel::WorkQueue::Dispatcher
+  RunResult = Data.define(:results, :retired)
+
   attr_reader :first_error
 
   def initialize(workers:, items:, prefetch:, item_timeout:, worker_max_items:, recycle_factory:)
@@ -21,7 +23,7 @@ class Evilution::Parallel::WorkQueue::Dispatcher
     seed
     collect
     @first_error = @state.first_error
-    [@state.results, @retired]
+    RunResult.new(results: @state.results, retired: @retired)
   end
 
   private

--- a/lib/evilution/parallel/work_queue/worker.rb
+++ b/lib/evilution/parallel/work_queue/worker.rb
@@ -6,6 +6,8 @@ require_relative "channel"
 require_relative "channel/frame"
 
 class Evilution::Parallel::WorkQueue::Worker
+  Timing = Data.define(:busy, :wall)
+
   attr_reader :pid, :worker_index
   attr_accessor :items_completed, :pending, :busy_time, :wall_time
 
@@ -84,11 +86,11 @@ class Evilution::Parallel::WorkQueue::Worker
 
   def retire
     shutdown
-    busy, wall = drain_stats
+    timing = drain_stats
     close_pipes
     reap
-    @busy_time = busy
-    @wall_time = wall
+    @busy_time = timing.busy
+    @wall_time = timing.wall
     to_stat
   end
 
@@ -101,14 +103,15 @@ class Evilution::Parallel::WorkQueue::Worker
   private
 
   def drain_stats
-    return [0.0, 0.0] unless @res_read.wait_readable(Evilution::Parallel::WorkQueue::TIMING_GRACE_PERIOD)
+    zero = Timing.new(busy: 0.0, wall: 0.0)
+    return zero unless @res_read.wait_readable(Evilution::Parallel::WorkQueue::TIMING_GRACE_PERIOD)
 
     message = read_result
-    return [0.0, 0.0] if message.nil?
+    return zero if message.nil?
 
     tag, busy, wall = message
-    return [0.0, 0.0] unless tag == Evilution::Parallel::WorkQueue::STATS
+    return zero unless tag == Evilution::Parallel::WorkQueue::STATS
 
-    [busy, wall]
+    Timing.new(busy: busy, wall: wall)
   end
 end

--- a/spec/evilution/parallel/work_queue/dispatcher_spec.rb
+++ b/spec/evilution/parallel/work_queue/dispatcher_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Evilution::Parallel::WorkQueue::Dispatcher do
         item_timeout: 5, worker_max_items: nil,
         recycle_factory: ->(_) { raise "should not recycle" }
       )
-      results, retired = dispatcher.run
-      expect(results).to eq([11])
-      expect(retired).to be_empty
+      run_result = dispatcher.run
+      expect(run_result.results).to eq([11])
+      expect(run_result.retired).to be_empty
       expect(dispatcher.first_error).to be_nil
 
       worker.shutdown
@@ -40,11 +40,11 @@ RSpec.describe Evilution::Parallel::WorkQueue::Dispatcher do
         item_timeout: 5, worker_max_items: 2,
         recycle_factory: factory
       )
-      results, retired = dispatcher.run
+      run_result = dispatcher.run
 
-      expect(results).to eq([1, 2, 3])
-      expect(retired.length).to eq(1)
-      expect(retired.first.items_completed).to eq(2)
+      expect(run_result.results).to eq([1, 2, 3])
+      expect(run_result.retired.length).to eq(1)
+      expect(run_result.retired.first.items_completed).to eq(2)
 
       replacement.shutdown if replacement
       replacement.close_pipes if replacement
@@ -60,7 +60,7 @@ RSpec.describe Evilution::Parallel::WorkQueue::Dispatcher do
         item_timeout: 5, worker_max_items: nil,
         recycle_factory: ->(_) { raise "no recycle" }
       )
-      _results, _retired = dispatcher.run
+      dispatcher.run
       expect(dispatcher.first_error).to be_a(StandardError)
       expect(dispatcher.first_error.message).to eq("boom")
 
@@ -78,7 +78,7 @@ RSpec.describe Evilution::Parallel::WorkQueue::Dispatcher do
         item_timeout: 0.2, worker_max_items: nil,
         recycle_factory: ->(_) { raise "no recycle" }
       )
-      _results, _retired = dispatcher.run
+      dispatcher.run
       expect(dispatcher.first_error).to be_a(Evilution::Error)
       expect(dispatcher.first_error.message).to match(/worker timed out/)
 


### PR DESCRIPTION
## Summary
- `Dispatcher#run` → returns `Dispatcher::RunResult = Data.define(:results, :retired)` (was `[results, retired]`)
- `Worker#drain_stats` → returns `Worker::Timing = Data.define(:busy, :wall)` (was `[busy, wall]`)
- `WorkQueue#map` and `Worker#retire` consume named accessors
- Dispatcher spec updated

Closes #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)