### PR TITLE
955: Replace file-and-range parser tuple returns with ParsedPaths Data

### DIFF
--- a/lib/evilution/cli/parser.rb
+++ b/lib/evilution/cli/parser.rb
@@ -20,7 +20,9 @@ class Evilution::CLI::Parser
 
     preprocess_flags
     remaining = OptionsBuilder.build(@options).parse!(@argv)
-    @files, @line_ranges = FileArgs.parse(remaining)
+    parsed_paths = FileArgs.parse(remaining)
+    @files = parsed_paths.files
+    @line_ranges = parsed_paths.ranges
     read_stdin_files if @options.delete(:stdin) && %i[run subjects].include?(@command)
     build_parsed_args
   end

--- a/lib/evilution/cli/parser/file_args.rb
+++ b/lib/evilution/cli/parser/file_args.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Evilution::CLI::Parser::FileArgs
+  ParsedPaths = Data.define(:files, :ranges)
+
   module_function
 
   def parse(raw_args)
@@ -15,7 +17,7 @@ module Evilution::CLI::Parser::FileArgs
       ranges[file] = parse_line_range(range_str)
     end
 
-    [files, ranges]
+    ParsedPaths.new(files: files, ranges: ranges)
   end
 
   def expand_spec_dir(dir)

--- a/lib/evilution/cli/parser/stdin_reader.rb
+++ b/lib/evilution/cli/parser/stdin_reader.rb
@@ -22,7 +22,7 @@ class Evilution::CLI::Parser::StdinReader
       line = line.strip
       lines << line unless line.empty?
     end
-    files, ranges = Evilution::CLI::Parser::FileArgs.parse(lines)
-    Result.new(files, ranges, nil)
+    parsed_paths = Evilution::CLI::Parser::FileArgs.parse(lines)
+    Result.new(parsed_paths.files, parsed_paths.ranges, nil)
   end
 end

--- a/lib/evilution/mcp/info_tool.rb
+++ b/lib/evilution/mcp/info_tool.rb
@@ -74,7 +74,13 @@ class Evilution::MCP::InfoTool < MCP::Tool
       return ResponseFormatter.error("config_error", "action is required") unless action
       return ResponseFormatter.error("config_error", "unknown action: #{action}") unless ACTIONS.key?(action)
 
-      parsed_files, line_ranges = RequestParser.parse_files(Array(files)) if files
+      parsed_files = nil
+      line_ranges = nil
+      if files
+        parsed = RequestParser.parse_files(Array(files))
+        parsed_files = parsed.files
+        line_ranges = parsed.ranges
+      end
 
       ACTIONS[action].call(
         files: parsed_files, line_ranges: line_ranges, target: target, spec: spec,

--- a/lib/evilution/mcp/info_tool/request_parser.rb
+++ b/lib/evilution/mcp/info_tool/request_parser.rb
@@ -3,6 +3,8 @@
 require_relative "../info_tool"
 
 module Evilution::MCP::InfoTool::RequestParser
+  ParsedPaths = Data.define(:files, :ranges)
+
   module_function
 
   def parse_files(raw_files)
@@ -15,7 +17,7 @@ module Evilution::MCP::InfoTool::RequestParser
       ranges[file] = parse_line_range(range_str) if range_str
     end
 
-    [files, ranges]
+    ParsedPaths.new(files: files, ranges: ranges)
   end
 
   def parse_line_range(str)

--- a/lib/evilution/mcp/mutate_tool.rb
+++ b/lib/evilution/mcp/mutate_tool.rb
@@ -120,10 +120,10 @@ class Evilution::MCP::MutateTool < MCP::Tool
 
     def build_config(files, opts)
       Evilution::MCP::MutateTool::OptionParser.validate!(opts)
-      parsed_files, line_ranges = Evilution::MCP::MutateTool::OptionParser.parse_files(Array(files))
+      parsed = Evilution::MCP::MutateTool::OptionParser.parse_files(Array(files))
       Evilution::MCP::MutateTool::ConfigBuilder.build(
-        files: parsed_files,
-        line_ranges: line_ranges,
+        files: parsed.files,
+        line_ranges: parsed.ranges,
         params: opts
       )
     end

--- a/lib/evilution/mcp/mutate_tool/option_parser.rb
+++ b/lib/evilution/mcp/mutate_tool/option_parser.rb
@@ -8,6 +8,8 @@ module Evilution::MCP::MutateTool::OptionParser
                         isolation baseline save_session].freeze
   ALLOWED_OPT_KEYS = (PASSTHROUGH_KEYS + %i[spec skip_config]).freeze
 
+  ParsedPaths = Data.define(:files, :ranges)
+
   def self.parse_files(raw_files)
     files = []
     ranges = {}
@@ -20,7 +22,7 @@ module Evilution::MCP::MutateTool::OptionParser
       ranges[file] = parse_line_range(range_str)
     end
 
-    [files, ranges]
+    ParsedPaths.new(files: files, ranges: ranges)
   end
 
   def self.parse_line_range(str)

--- a/spec/evilution/cli/parser/file_args_spec.rb
+++ b/spec/evilution/cli/parser/file_args_spec.rb
@@ -6,34 +6,36 @@ require "evilution/cli/parser/file_args"
 RSpec.describe Evilution::CLI::Parser::FileArgs do
   describe ".parse" do
     it "returns empty files and ranges for empty input" do
-      expect(described_class.parse([])).to eq([[], {}])
+      parsed = described_class.parse([])
+      expect(parsed.files).to eq([])
+      expect(parsed.ranges).to eq({})
     end
 
     it "collects positional files" do
-      files, ranges = described_class.parse(%w[lib/a.rb lib/b.rb])
-      expect(files).to eq(%w[lib/a.rb lib/b.rb])
-      expect(ranges).to eq({})
+      parsed = described_class.parse(%w[lib/a.rb lib/b.rb])
+      expect(parsed.files).to eq(%w[lib/a.rb lib/b.rb])
+      expect(parsed.ranges).to eq({})
     end
 
     it "parses a single line" do
-      _files, ranges = described_class.parse(["lib/a.rb:10"])
-      expect(ranges["lib/a.rb"]).to eq(10..10)
+      parsed = described_class.parse(["lib/a.rb:10"])
+      expect(parsed.ranges["lib/a.rb"]).to eq(10..10)
     end
 
     it "parses a bounded range" do
-      _files, ranges = described_class.parse(["lib/a.rb:15-30"])
-      expect(ranges["lib/a.rb"]).to eq(15..30)
+      parsed = described_class.parse(["lib/a.rb:15-30"])
+      expect(parsed.ranges["lib/a.rb"]).to eq(15..30)
     end
 
     it "parses an open-ended range" do
-      _files, ranges = described_class.parse(["lib/a.rb:15-"])
-      expect(ranges["lib/a.rb"]).to eq(15..Float::INFINITY)
+      parsed = described_class.parse(["lib/a.rb:15-"])
+      expect(parsed.ranges["lib/a.rb"]).to eq(15..Float::INFINITY)
     end
 
     it "combines files with and without ranges" do
-      files, ranges = described_class.parse(["lib/a.rb", "lib/b.rb:5-10"])
-      expect(files).to eq(%w[lib/a.rb lib/b.rb])
-      expect(ranges).to eq("lib/b.rb" => (5..10))
+      parsed = described_class.parse(["lib/a.rb", "lib/b.rb:5-10"])
+      expect(parsed.files).to eq(%w[lib/a.rb lib/b.rb])
+      expect(parsed.ranges).to eq("lib/b.rb" => (5..10))
     end
   end
 

--- a/spec/evilution/mcp/info_tool/request_parser_spec.rb
+++ b/spec/evilution/mcp/info_tool/request_parser_spec.rb
@@ -5,36 +5,38 @@ require "evilution/mcp/info_tool/request_parser"
 
 RSpec.describe Evilution::MCP::InfoTool::RequestParser do
   describe ".parse_files" do
-    it "returns ([], {}) for empty input" do
-      expect(described_class.parse_files([])).to eq([[], {}])
+    it "returns empty files and ranges for empty input" do
+      parsed = described_class.parse_files([])
+      expect(parsed.files).to eq([])
+      expect(parsed.ranges).to eq({})
     end
 
     it "extracts file without range" do
-      files, ranges = described_class.parse_files(["lib/foo.rb"])
-      expect(files).to eq(["lib/foo.rb"])
-      expect(ranges).to eq({})
+      parsed = described_class.parse_files(["lib/foo.rb"])
+      expect(parsed.files).to eq(["lib/foo.rb"])
+      expect(parsed.ranges).to eq({})
     end
 
     it "extracts file with single-line range" do
-      files, ranges = described_class.parse_files(["lib/foo.rb:15"])
-      expect(files).to eq(["lib/foo.rb"])
-      expect(ranges).to eq("lib/foo.rb" => (15..15))
+      parsed = described_class.parse_files(["lib/foo.rb:15"])
+      expect(parsed.files).to eq(["lib/foo.rb"])
+      expect(parsed.ranges).to eq("lib/foo.rb" => (15..15))
     end
 
     it "extracts file with closed range" do
-      _files, ranges = described_class.parse_files(["lib/foo.rb:15-30"])
-      expect(ranges).to eq("lib/foo.rb" => (15..30))
+      parsed = described_class.parse_files(["lib/foo.rb:15-30"])
+      expect(parsed.ranges).to eq("lib/foo.rb" => (15..30))
     end
 
     it "extracts file with open-ended range" do
-      _files, ranges = described_class.parse_files(["lib/foo.rb:15-"])
-      expect(ranges["lib/foo.rb"]).to eq(15..Float::INFINITY)
+      parsed = described_class.parse_files(["lib/foo.rb:15-"])
+      expect(parsed.ranges["lib/foo.rb"]).to eq(15..Float::INFINITY)
     end
 
     it "handles multiple files" do
-      files, ranges = described_class.parse_files(["a.rb:1-3", "b.rb"])
-      expect(files).to eq(["a.rb", "b.rb"])
-      expect(ranges).to eq("a.rb" => (1..3))
+      parsed = described_class.parse_files(["a.rb:1-3", "b.rb"])
+      expect(parsed.files).to eq(["a.rb", "b.rb"])
+      expect(parsed.ranges).to eq("a.rb" => (1..3))
     end
   end
 

--- a/spec/evilution/mcp/info_tool_spec.rb
+++ b/spec/evilution/mcp/info_tool_spec.rb
@@ -84,7 +84,8 @@ RSpec.describe Evilution::MCP::InfoTool do
 
     it "invokes RequestParser.parse_files when files is present" do
       expect(Evilution::MCP::InfoTool::RequestParser).to receive(:parse_files)
-        .with(["lib/foo.rb"]).and_return([["lib/foo.rb"], {}])
+        .with(["lib/foo.rb"])
+        .and_return(Evilution::MCP::InfoTool::RequestParser::ParsedPaths.new(files: ["lib/foo.rb"], ranges: {}))
       call(action: "subjects", files: ["lib/foo.rb"])
     end
 

--- a/spec/evilution/mcp/mutate_tool/option_parser_spec.rb
+++ b/spec/evilution/mcp/mutate_tool/option_parser_spec.rb
@@ -5,23 +5,25 @@ require "evilution/mcp/mutate_tool"
 RSpec.describe Evilution::MCP::MutateTool::OptionParser do
   describe ".parse_files" do
     it "returns plain files and empty ranges when no colon" do
-      expect(described_class.parse_files(%w[lib/a.rb lib/b.rb])).to eq([%w[lib/a.rb lib/b.rb], {}])
+      parsed = described_class.parse_files(%w[lib/a.rb lib/b.rb])
+      expect(parsed.files).to eq(%w[lib/a.rb lib/b.rb])
+      expect(parsed.ranges).to eq({})
     end
 
     it "extracts a single-line range" do
-      files, ranges = described_class.parse_files(["lib/a.rb:42"])
-      expect(files).to eq(["lib/a.rb"])
-      expect(ranges).to eq("lib/a.rb" => (42..42))
+      parsed = described_class.parse_files(["lib/a.rb:42"])
+      expect(parsed.files).to eq(["lib/a.rb"])
+      expect(parsed.ranges).to eq("lib/a.rb" => (42..42))
     end
 
     it "extracts a bounded range" do
-      _, ranges = described_class.parse_files(["lib/a.rb:10-20"])
-      expect(ranges).to eq("lib/a.rb" => (10..20))
+      parsed = described_class.parse_files(["lib/a.rb:10-20"])
+      expect(parsed.ranges).to eq("lib/a.rb" => (10..20))
     end
 
     it "treats an open upper bound as infinity" do
-      _, ranges = described_class.parse_files(["lib/a.rb:10-"])
-      expect(ranges["lib/a.rb"]).to eq(10..Float::INFINITY)
+      parsed = described_class.parse_files(["lib/a.rb:10-"])
+      expect(parsed.ranges["lib/a.rb"]).to eq(10..Float::INFINITY)
     end
 
     it "raises ParseError for non-numeric range" do


### PR DESCRIPTION
## Summary
- Add `ParsedPaths = Data.define(:files, :ranges)` inside each parser module:
  - `CLI::Parser::FileArgs::ParsedPaths`
  - `MCP::MutateTool::OptionParser::ParsedPaths`
  - `MCP::InfoTool::RequestParser::ParsedPaths`
- Each `parse`/`parse_files` returns `ParsedPaths` instead of `[files, ranges]`
- All callers (`CLI::Parser`, `StdinReader`, `MutateTool#build_config`, `InfoTool.call`) consume via `.files` / `.ranges`
- Specs updated

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)