### PR TITLE
858: Stabilize MCP tool contracts and introduce schema versioning for…

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -317,3 +317,4 @@
 {"id":"int-a16fb04a","kind":"field_change","created_at":"2026-05-07T08:38:44.320058211Z","actor":"Denis Kiselev","issue_id":"EV-i5yp","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"merged via PR #1163"}}
 {"id":"int-3571ab77","kind":"field_change","created_at":"2026-05-07T09:00:32.015564768Z","actor":"Denis Kiselev","issue_id":"EV-vtoe","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"merged"}}
 {"id":"int-59058caf","kind":"field_change","created_at":"2026-05-07T10:50:55.015519734Z","actor":"Denis Kiselev","issue_id":"EV-jmq4","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"merged"}}
+{"id":"int-3fb9d199","kind":"field_change","created_at":"2026-05-07T13:05:45.604108546Z","actor":"Denis Kiselev","issue_id":"EV-1l8z","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"merged"}}

--- a/README.md
+++ b/README.md
@@ -557,21 +557,24 @@ The three MCP tools (`evilution-mutate`, `evilution-session`, `evilution-info`) 
 - **Input schemas**: every parameter listed in each tool's `input_schema` (name, type, enum values, `required`).
 - **Action enumerations**: the action enum on `evilution-session` (`list`, `show`, `diff`) and `evilution-info` (`subjects`, `tests`, `environment`, `statuses`, `feedback`).
 - **Output payload top-level shape**: the keys and value types documented per action below.
-- **Error envelope**: an error response is a single text content with body `{ "error": { "type": <string>, "message": <string> } }` and the response's `error` flag set to true. The error type strings (`config_error`, `parse_error`, `not_found`, `runtime_error`, `validation_error`, `tool_error`) are part of the contract.
+- **Error envelope**: an error response is a single text content with the response's `error` flag set to true. The body is a JSON object with at minimum an `error` key shaped `{ "type": <string>, "message": <string> }`; tools may add additional top-level keys (e.g. `evilution-mutate` includes `feedback_url` and `feedback_hint` to point agents at the public Discussions channel). Consumers must read the `error.type` discriminator and ignore unknown extras. The error type strings — currently `config_error`, `parse_error`, `not_found`, and `runtime_error` — are part of the contract; new types may be added in MINOR releases (additive).
 
 #### Output `schema_version`
 
-Each MCP tool emits a `schema_version` integer scoped to the **MCP contract** (`Evilution::MCP::CONTRACT_VERSION`, currently `1`):
+Successful MCP responses carry a top-level `schema_version` integer. Two distinct version spaces are in play; both happen to be `1` today and either may be bumped independently at the next MAJOR release:
 
-| Tool / action                  | Where `schema_version` lives                                                                                                                                           |
-|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `evilution-mutate`             | Top-level of the mutation report JSON. (Note: this field is governed by `Evilution::Session::Schema::CURRENT_VERSION` — the report shape is shared with session JSON.) |
-| `evilution-session` `list`     | Top-level of the envelope: `{ "schema_version": 1, "sessions": [...] }`.                                                                                               |
-| `evilution-session` `show`     | Inside the returned session JSON document (governed by `Evilution::Session::Schema::CURRENT_VERSION`).                                                                 |
-| `evilution-session` `diff`     | Top-level of the diff payload, alongside `summary` / `fixed` / `new_survivors` / `persistent`.                                                                         |
-| `evilution-info` (all actions) | Top-level of every successful response, injected by the action response formatter.                                                                                     |
+- **MCP contract `schema_version`** — `Evilution::MCP::CONTRACT_VERSION` (currently `1`). Stamped on envelopes that exist solely to wrap MCP tool output: `evilution-info` action responses, `evilution-session list`, `evilution-session diff`. Bumped only when the MCP envelope shape itself changes incompatibly.
+- **Session JSON `schema_version`** — `Evilution::Session::Schema::CURRENT_VERSION` (currently `1`). Embedded inside payloads whose shape is also written to disk and consumed elsewhere: `evilution-mutate` (returns a mutation report) and `evilution-session show` (returns a session JSON document). Bumped only when the report/session shape itself changes incompatibly.
 
-The MCP contract version (`Evilution::MCP::CONTRACT_VERSION`) is **independent** of the session JSON schema version (`Evilution::Session::Schema::CURRENT_VERSION`). They happen to both be `1` today; either may be bumped independently at the next MAJOR release if its surface gains an incompatible change.
+Per-tool placement:
+
+| Tool / action                  | `schema_version` source                  | Location in payload                                                                                  |
+|--------------------------------|------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `evilution-mutate`             | `Session::Schema::CURRENT_VERSION`       | Top-level of the mutation report JSON (same shape as `--save-session` output).                      |
+| `evilution-session` `list`     | `MCP::CONTRACT_VERSION`                  | Top-level of envelope: `{ "schema_version": 1, "sessions": [...] }`.                                 |
+| `evilution-session` `show`     | `Session::Schema::CURRENT_VERSION`       | Inside the returned session JSON document.                                                           |
+| `evilution-session` `diff`     | `MCP::CONTRACT_VERSION`                  | Top-level alongside `summary` / `fixed` / `new_survivors` / `persistent`.                            |
+| `evilution-info` (all actions) | `MCP::CONTRACT_VERSION`                  | Top-level of every successful response, injected by the action response formatter.                   |
 
 #### Per-tool output shapes
 

--- a/README.md
+++ b/README.md
@@ -549,6 +549,59 @@ When evilution causes friction (errors, usage problems, missing capabilities you
 
 Discussion URL: <https://github.com/marinazzio/evilution/discussions>
 
+### Contract stability
+
+The three MCP tools (`evilution-mutate`, `evilution-session`, `evilution-info`) form evilution's public contract for AI agents. From `1.0.0` onwards the following are governed by the gem's [SemVer policy](docs/versioning.md):
+
+- **Tool names**: `evilution-mutate`, `evilution-session`, `evilution-info`.
+- **Input schemas**: every parameter listed in each tool's `input_schema` (name, type, enum values, `required`).
+- **Action enumerations**: the action enum on `evilution-session` (`list`, `show`, `diff`) and `evilution-info` (`subjects`, `tests`, `environment`, `statuses`, `feedback`).
+- **Output payload top-level shape**: the keys and value types documented per action below.
+- **Error envelope**: an error response is a single text content with body `{ "error": { "type": <string>, "message": <string> } }` and the response's `error` flag set to true. The error type strings (`config_error`, `parse_error`, `not_found`, `runtime_error`, `validation_error`, `tool_error`) are part of the contract.
+
+#### Output `schema_version`
+
+Each MCP tool emits a `schema_version` integer scoped to the **MCP contract** (`Evilution::MCP::CONTRACT_VERSION`, currently `1`):
+
+| Tool / action                  | Where `schema_version` lives                                                                                                                                           |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `evilution-mutate`             | Top-level of the mutation report JSON. (Note: this field is governed by `Evilution::Session::Schema::CURRENT_VERSION` — the report shape is shared with session JSON.) |
+| `evilution-session` `list`     | Top-level of the envelope: `{ "schema_version": 1, "sessions": [...] }`.                                                                                               |
+| `evilution-session` `show`     | Inside the returned session JSON document (governed by `Evilution::Session::Schema::CURRENT_VERSION`).                                                                 |
+| `evilution-session` `diff`     | Top-level of the diff payload, alongside `summary` / `fixed` / `new_survivors` / `persistent`.                                                                         |
+| `evilution-info` (all actions) | Top-level of every successful response, injected by the action response formatter.                                                                                     |
+
+The MCP contract version (`Evilution::MCP::CONTRACT_VERSION`) is **independent** of the session JSON schema version (`Evilution::Session::Schema::CURRENT_VERSION`). They happen to both be `1` today; either may be bumped independently at the next MAJOR release if its surface gains an incompatible change.
+
+#### Per-tool output shapes
+
+- **`evilution-mutate`** — full schema in the [JSON Output Schema](#json-output-schema) section. MCP-specific additions to each `survived` entry are documented in [Enriched Survived Entries](#enriched-survived-entries).
+- **`evilution-session` `list`** — `{ "schema_version": Integer, "sessions": Array<{ file, timestamp, total, killed, survived, score, duration }> }`. Sessions are reverse-chronological; the array is filtered by `limit` when provided.
+- **`evilution-session` `show`** — the parsed session JSON document, exactly as written under `.evilution/results/*.json`. Field reference: see [Session JSON files](#session-json-files).
+- **`evilution-session` `diff`** — `{ "schema_version": Integer, "summary": { base_score, head_score, score_delta, base_survived, head_survived, base_total, head_total, base_killed, head_killed }, "fixed": Array, "new_survivors": Array, "persistent": Array }`. The mutation arrays carry the same per-mutation fields the session `survived` list uses (`operator`, `file`, `line`, `subject`, `diff`).
+- **`evilution-info` `subjects`** — `{ "schema_version": Integer, "subjects": Array<{ name, file, line, mutations }>, "total_subjects": Integer, "total_mutations": Integer }`.
+- **`evilution-info` `tests`** — `{ "schema_version": Integer, "specs": Array<{ source, spec }>, "unresolved": Array<String>, "total_sources": Integer, "total_specs": Integer }`.
+- **`evilution-info` `environment`** — `{ "schema_version": Integer, "version": String, "ruby": String, "config_file": String|null, ... }` mirroring the effective `Evilution::Config`.
+- **`evilution-info` `statuses`** — `{ "schema_version": Integer, "statuses": Array<{ name, meaning, in_score }> }`.
+- **`evilution-info` `feedback`** — `{ "schema_version": Integer, "discussion_url": String, "consent": String, "privacy": String }`.
+
+#### Deprecation cycle
+
+When a parameter, action, or output field on the public MCP contract is deprecated:
+
+1. The deprecation is announced in the CHANGELOG and the tool's `description` text gains a deprecation note.
+2. The deprecated form remains functional for the entire `1.x` line — a deprecation introduced in `1.X` continues to work in every subsequent `1.X+N` release.
+3. The earliest release that may remove the deprecated form is `2.0`. Removals are listed in the major-release migration guide.
+4. Adding new parameters, new actions, or new top-level output fields is additive and ships in MINOR releases (existing consumers continue to work).
+
+#### Not covered by the contract
+
+- The exact wording of error `message` strings (the `type` is contract; the message is a hint that may be reworded).
+- The exact ordering of arrays whose contract calls only for membership (e.g. `unresolved` source files).
+- Progress-stream notification payloads sent through `server_context.notifications` — these are best-effort UI signals, not a stable API.
+- Performance characteristics (request latency, memory, parallelism) — improvements ship in any release; regressions are bugs but not contract violations.
+- Default values that are part of the gem's user-facing semantics (timeout, integration default, etc.) — these follow the umbrella SemVer policy and may be tuned.
+
 ## Recommended Workflows for AI Agents
 
 ### 1. Full project scan

--- a/lib/evilution/mcp.rb
+++ b/lib/evilution/mcp.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 module Evilution::MCP
+  # Public contract version for the evilution MCP tool surface (input schemas,
+  # output payload shapes, error envelope, action enumerations). Bumped only
+  # at MAJOR releases per docs/versioning.md. Independent of session JSON
+  # schema versioning (Evilution::Session::Schema) so the two surfaces can
+  # rev separately.
+  CONTRACT_VERSION = 1
 end

--- a/lib/evilution/mcp/info_tool.rb
+++ b/lib/evilution/mcp/info_tool.rb
@@ -27,7 +27,9 @@ class Evilution::MCP::InfoTool < MCP::Tool
               "'feedback' returns the public discussion URL plus consent and privacy guidance for posting " \
               "feedback on errors, usage problems, friction, or missing capabilities. " \
               "Use this instead of shelling out to 'evilution subjects', 'evilution tests list', or 'evilution environment show' — " \
-              "the response is structured JSON so you can plan the next mutation run without parsing CLI text."
+              "the response is structured JSON so you can plan the next mutation run without parsing CLI text. " \
+              "Contract: input schema, action enum, and per-action output shapes are stable for the 1.x line; " \
+              "see README \"MCP Server\" section for the full deprecation policy."
   input_schema(
     properties: {
       action: {

--- a/lib/evilution/mcp/info_tool/response_formatter.rb
+++ b/lib/evilution/mcp/info_tool/response_formatter.rb
@@ -7,9 +7,22 @@ require_relative "error_mapper"
 module Evilution::MCP::InfoTool::ResponseFormatter
   module_function
 
+  # Wraps the payload as a successful MCP text response and injects the
+  # outer-envelope schema_version so agents that cache contracts can detect
+  # incompatible servers. Existing schema_version keys in the payload are
+  # preserved (e.g. session JSON keeps its own schema_version unchanged).
   def success(payload)
-    ::MCP::Tool::Response.new([{ type: "text", text: ::JSON.generate(payload) }])
+    versioned = inject_schema_version(payload)
+    ::MCP::Tool::Response.new([{ type: "text", text: ::JSON.generate(versioned) }])
   end
+
+  def inject_schema_version(payload)
+    return payload unless payload.is_a?(Hash)
+    return payload if payload.key?("schema_version") || payload.key?(:schema_version)
+
+    { "schema_version" => Evilution::MCP::CONTRACT_VERSION }.merge(payload)
+  end
+  private_class_method :inject_schema_version
 
   def error(type, message)
     ::MCP::Tool::Response.new(

--- a/lib/evilution/mcp/mutate_tool.rb
+++ b/lib/evilution/mcp/mutate_tool.rb
@@ -28,7 +28,9 @@ class Evilution::MCP::MutateTool < MCP::Tool
               "Prefer this over shelling out to 'evilution' — the response is machine-readable " \
               "and already trimmed for survived-mutant triage. " \
               "Hitting errors, friction, or missing capabilities? See evilution-info action=feedback for the " \
-              "public feedback channel — ask the user before posting anything."
+              "public feedback channel — ask the user before posting anything. " \
+              "Contract: input schema and output payload are stable for the 1.x line; " \
+              "see README \"MCP Server\" section for the full deprecation policy."
   input_schema(
     properties: {
       files: {

--- a/lib/evilution/mcp/session_tool.rb
+++ b/lib/evilution/mcp/session_tool.rb
@@ -15,7 +15,9 @@ class Evilution::MCP::SessionTool < MCP::Tool
               "'show' returns the full report for a session (summary, survived mutations with diffs, git context), " \
               "'diff' compares two sessions and surfaces new regressions, fixed mutations, persistent survivors, and score delta. " \
               "Prefer this over the CLI when auditing mutation score trends, triaging survivors, " \
-              "or verifying that a fix killed the right mutant."
+              "or verifying that a fix killed the right mutant. " \
+              "Contract: input schema, action enum, and output payloads are stable for the 1.x line; " \
+              "see README \"MCP Server\" section for the full deprecation policy."
   input_schema(
     properties: {
       action: {
@@ -77,8 +79,8 @@ class Evilution::MCP::SessionTool < MCP::Tool
       entries = store.list
       entries = entries.first(result.limit) unless result.limit.nil?
 
-      payload = entries.map { |e| e.transform_keys(&:to_s) }
-      success_response(payload)
+      sessions = entries.map { |e| e.transform_keys(&:to_s) }
+      success_response("schema_version" => Evilution::MCP::CONTRACT_VERSION, "sessions" => sessions)
     end
 
     def normalize_limit(limit)
@@ -115,7 +117,8 @@ class Evilution::MCP::SessionTool < MCP::Tool
       return validation if validation
 
       result = load_and_diff(base, head, dir)
-      success_response(result.to_h)
+      payload = { "schema_version" => Evilution::MCP::CONTRACT_VERSION }.merge(result.to_h)
+      success_response(payload)
     rescue Evilution::Error => e
       error_response("not_found", e.message)
     rescue ::JSON::ParserError => e

--- a/spec/evilution/mcp/info_tool/response_formatter_spec.rb
+++ b/spec/evilution/mcp/info_tool/response_formatter_spec.rb
@@ -13,12 +13,28 @@ RSpec.describe Evilution::MCP::InfoTool::ResponseFormatter do
     it "wraps payload as a single text-content MCP response" do
       response = described_class.success("ok" => true)
       expect(response).to be_a(MCP::Tool::Response)
-      expect(parse_body(response)).to eq("ok" => true)
+      expect(parse_body(response)).to include("ok" => true)
     end
 
     it "does not mark the response as an error" do
       response = described_class.success("x" => 1)
       expect(response.error?).to be_falsey
+    end
+
+    it "injects schema_version equal to MCP::CONTRACT_VERSION" do
+      response = described_class.success("ok" => true)
+      expect(parse_body(response)["schema_version"]).to eq(Evilution::MCP::CONTRACT_VERSION)
+    end
+
+    it "places schema_version first in the JSON output for discoverability" do
+      response = described_class.success("ok" => true, "extra" => 1)
+      keys = parse_body(response).keys
+      expect(keys.first).to eq("schema_version")
+    end
+
+    it "does not overwrite an existing schema_version key in the payload" do
+      response = described_class.success("schema_version" => 99, "ok" => true)
+      expect(parse_body(response)["schema_version"]).to eq(99)
     end
   end
 

--- a/spec/evilution/mcp/session_tool_spec.rb
+++ b/spec/evilution/mcp/session_tool_spec.rb
@@ -70,21 +70,24 @@ RSpec.describe Evilution::MCP::SessionTool do
   end
 
   describe "action: list" do
-    it "returns an array of sessions" do
+    it "returns an envelope containing schema_version and a sessions array" do
       write_session("20260320T100000-aabb0000.json",
                     session_summary(timestamp: "2026-03-20T10:00:00+00:00"))
 
       data = parse_response(call(action: "list", results_dir: results_dir))
 
-      expect(data).to be_an(Array)
-      expect(data.length).to eq(1)
-      expect(data.first["timestamp"]).to eq("2026-03-20T10:00:00+00:00")
+      expect(data).to be_a(Hash)
+      expect(data["schema_version"]).to eq(Evilution::MCP::CONTRACT_VERSION)
+      expect(data["sessions"]).to be_an(Array)
+      expect(data["sessions"].length).to eq(1)
+      expect(data["sessions"].first["timestamp"]).to eq("2026-03-20T10:00:00+00:00")
     end
 
-    it "returns empty array when no sessions exist" do
+    it "returns an empty sessions array (still wrapped in envelope) when no sessions exist" do
       data = parse_response(call(action: "list", results_dir: results_dir))
 
-      expect(data).to eq([])
+      expect(data["schema_version"]).to eq(Evilution::MCP::CONTRACT_VERSION)
+      expect(data["sessions"]).to eq([])
     end
 
     it "returns sessions in reverse chronological order" do
@@ -95,7 +98,7 @@ RSpec.describe Evilution::MCP::SessionTool do
 
       data = parse_response(call(action: "list", results_dir: results_dir))
 
-      expect(data.first["timestamp"]).to eq("2026-03-21T10:00:00+00:00")
+      expect(data["sessions"].first["timestamp"]).to eq("2026-03-21T10:00:00+00:00")
     end
 
     it "respects limit parameter" do
@@ -108,8 +111,8 @@ RSpec.describe Evilution::MCP::SessionTool do
 
       data = parse_response(call(action: "list", results_dir: results_dir, limit: 2))
 
-      expect(data.length).to eq(2)
-      expect(data.first["timestamp"]).to eq("2026-03-22T10:00:00+00:00")
+      expect(data["sessions"].length).to eq(2)
+      expect(data["sessions"].first["timestamp"]).to eq("2026-03-22T10:00:00+00:00")
     end
 
     it "uses default results directory when results_dir is not specified" do
@@ -142,7 +145,7 @@ RSpec.describe Evilution::MCP::SessionTool do
 
       data = parse_response(call(action: "list", results_dir: results_dir, limit: 0))
 
-      expect(data).to eq([])
+      expect(data["sessions"]).to eq([])
     end
 
     it "coerces integer-like string limit" do
@@ -153,7 +156,7 @@ RSpec.describe Evilution::MCP::SessionTool do
 
       data = parse_response(call(action: "list", results_dir: results_dir, limit: "1"))
 
-      expect(data.length).to eq(1)
+      expect(data["sessions"].length).to eq(1)
     end
   end
 
@@ -291,6 +294,15 @@ RSpec.describe Evilution::MCP::SessionTool do
       expect(data["fixed"].first["subject"]).to eq("Foo#baz")
       expect(data["persistent"].length).to eq(1)
       expect(data["new_survivors"]).to eq([])
+    end
+
+    it "includes the MCP contract schema_version on the diff output" do
+      base_path = write_session("base.json", diff_session(score: 0.8, survivors: []))
+      head_path = write_session("head.json", diff_session(score: 0.9, survivors: []))
+
+      data = parse_response(call(action: "diff", base: base_path, head: head_path, results_dir: results_dir))
+
+      expect(data["schema_version"]).to eq(Evilution::MCP::CONTRACT_VERSION)
     end
 
     it "returns error when base is not provided" do

--- a/spec/evilution/mcp_spec.rb
+++ b/spec/evilution/mcp_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "evilution/mcp"
+
+RSpec.describe Evilution::MCP do
+  describe "CONTRACT_VERSION" do
+    it "is defined as an Integer" do
+      expect(described_class::CONTRACT_VERSION).to be_a(Integer)
+    end
+
+    it "is 1 (initial 1.0 contract)" do
+      expect(described_class::CONTRACT_VERSION).to eq(1)
+    end
+
+    it "is independent of Session::Schema::CURRENT_VERSION (different surfaces, may diverge)" do
+      require "evilution/session/schema"
+      # Today they happen to be equal; the test just asserts both constants exist
+      # so a future MCP contract bump (without a session-JSON bump) doesn't break
+      # this spec — it only documents the dual identity.
+      expect(described_class::CONTRACT_VERSION).to be_a(Integer)
+      expect(Evilution::Session::Schema::CURRENT_VERSION).to be_a(Integer)
+    end
+  end
+end


### PR DESCRIPTION
… responses

- Added CONTRACT_VERSION to Evilution::MCP for versioning the public contract.
- Updated README.md with details on contract stability and deprecation policy.
- Modified response formatters to include schema_version in payloads.
- Adjusted session and mutate tools to return schema_version in responses.
- Enhanced tests to verify schema_version inclusion and contract stability.