### PR TITLE
1213: Fix mutation scoring by distinguishing between failed tests and…

### DIFF
--- a/lib/evilution/baseline.rb
+++ b/lib/evilution/baseline.rb
@@ -15,16 +15,18 @@ class Evilution::Baseline
     end
   end
 
-  def initialize(spec_resolver: Evilution::SpecResolver.new, timeout: 30, runner: nil, fallback_dir: "spec")
+  def initialize(spec_resolver: Evilution::SpecResolver.new, timeout: 30, runner: nil,
+                 fallback_dir: "spec", test_files: nil)
     @spec_resolver = spec_resolver
     @timeout = timeout
     @runner = runner
     @fallback_dir = fallback_dir
+    @test_files = test_files
   end
 
   def call(subjects)
     start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    spec_files = resolve_unique_spec_files(subjects)
+    spec_files = baseline_spec_files(subjects)
     failed = Set.new
 
     spec_files.each do |spec_file|
@@ -95,6 +97,17 @@ class Evilution::Baseline
   end
 
   private
+
+  # When --spec was provided, run those files only. Auto-discovery is skipped
+  # entirely — the user has declared what covers their subjects and any
+  # mismatch between auto-discovery and their declaration is what produced
+  # the misleading "No matching test found" warning users have reported even
+  # while passing --spec.
+  def baseline_spec_files(subjects)
+    return Array(@test_files).uniq if @test_files && !@test_files.empty?
+
+    resolve_unique_spec_files(subjects)
+  end
 
   def resolve_unique_spec_files(subjects)
     warned = Set.new

--- a/lib/evilution/integration/rspec.rb
+++ b/lib/evilution/integration/rspec.rb
@@ -82,12 +82,27 @@ class Evilution::Integration::RSpec < Evilution::Integration::Base
     snapshot = @state_guard.snapshot
     begin
       status = ::RSpec::Core::Runner.run(args, StringIO.new, StringIO.new)
-      @result_builder.from_run(status, command, detector)
+      @result_builder.from_run(status, command, detector, examples_executed: examples_loaded)
     rescue StandardError => e
       { passed: false, error: e.message, test_command: command }
     ensure
       @state_guard.release(snapshot)
     end
+  end
+
+  # Count of examples loaded into RSpec.world by this run. Used to distinguish
+  # "test failed → mutation killed" (positive count, nonzero status) from
+  # "spec file failed to load / RSpec returned nonzero with nothing observed"
+  # (zero count, nonzero status). The latter must NOT be classified as killed
+  # — silently counting it would inflate scores with mutations no example
+  # actually saw (EV-720r).
+  def examples_loaded
+    world = ::RSpec.world
+    return nil unless world.respond_to?(:example_count)
+
+    world.example_count
+  rescue StandardError
+    nil
   end
 
   def reset_examples

--- a/lib/evilution/integration/rspec.rb
+++ b/lib/evilution/integration/rspec.rb
@@ -82,7 +82,7 @@ class Evilution::Integration::RSpec < Evilution::Integration::Base
     snapshot = @state_guard.snapshot
     begin
       status = ::RSpec::Core::Runner.run(args, StringIO.new, StringIO.new)
-      @result_builder.from_run(status, command, detector, examples_executed: examples_loaded)
+      @result_builder.from_run(status, command, detector, examples_loaded:)
     rescue StandardError => e
       { passed: false, error: e.message, test_command: command }
     ensure

--- a/lib/evilution/integration/rspec/result_builder.rb
+++ b/lib/evilution/integration/rspec/result_builder.rb
@@ -21,7 +21,7 @@ class Evilution::Integration::RSpec::ResultBuilder
     }
   end
 
-  def from_run(status, command, detector)
+  def from_run(status, command, detector, examples_executed: nil)
     return { passed: true, test_command: command } if status.zero?
 
     if detector.only_crashes?
@@ -31,6 +31,22 @@ class Evilution::Integration::RSpec::ResultBuilder
         test_crashed: true,
         error: "test crashes: #{detector.crash_summary}",
         error_class: (classes.first if classes.length == 1),
+        test_command: command
+      }
+    end
+
+    # Nonzero exit + zero examples = no observation of the mutation. Surfacing
+    # this as a generic fail would let classify_status fall through to its
+    # :killed default and silently inflate the kill count even though the
+    # spec suite never actually ran a single example against the mutation
+    # (EV-720r: macOS Rails users hit fail_if_no_examples / autoload issues
+    # that yielded killed=100% with empty worker output).
+    if !examples_executed.nil? && examples_executed.zero?
+      return {
+        passed: false,
+        error: "RSpec exited #{status} but ran 0 examples — no examples ran against the mutation. " \
+               "Likely the spec file failed to load, --spec was misrouted, or RSpec is configured " \
+               "with fail_if_no_examples. The mutation cannot be counted as killed.",
         test_command: command
       }
     end

--- a/lib/evilution/integration/rspec/result_builder.rb
+++ b/lib/evilution/integration/rspec/result_builder.rb
@@ -21,7 +21,7 @@ class Evilution::Integration::RSpec::ResultBuilder
     }
   end
 
-  def from_run(status, command, detector, examples_executed: nil)
+  def from_run(status, command, detector, examples_loaded: nil)
     return { passed: true, test_command: command } if status.zero?
 
     if detector.only_crashes?
@@ -35,16 +35,19 @@ class Evilution::Integration::RSpec::ResultBuilder
       }
     end
 
-    # Nonzero exit + zero examples = no observation of the mutation. Surfacing
-    # this as a generic fail would let classify_status fall through to its
-    # :killed default and silently inflate the kill count even though the
-    # spec suite never actually ran a single example against the mutation
-    # (EV-720r: macOS Rails users hit fail_if_no_examples / autoload issues
-    # that yielded killed=100% with empty worker output).
-    if !examples_executed.nil? && examples_executed.zero?
+    # Nonzero exit + zero examples loaded = the spec file did not register any
+    # examples (load error, autoload mismatch, etc.), so nothing ran against
+    # the mutation. Surfacing this as a generic fail would let classify_status
+    # fall through to its :killed default and silently inflate the kill count
+    # even though no example ever observed the mutation (EV-720r: macOS Rails
+    # users hit autoload / fail_if_no_examples paths that yielded killed=100%
+    # with empty worker output). Note: this checks LOADED count, not executed
+    # count — filters/skip/--fail-fast can leave loaded > executed, but the
+    # "spec failed to load entirely" case is the failure mode this guard targets.
+    if !examples_loaded.nil? && examples_loaded.zero?
       return {
         passed: false,
-        error: "RSpec exited #{status} but ran 0 examples — no examples ran against the mutation. " \
+        error: "RSpec exited #{status} but loaded 0 examples — no examples ran against the mutation. " \
                "Likely the spec file failed to load, --spec was misrouted, or RSpec is configured " \
                "with fail_if_no_examples. The mutation cannot be counted as killed.",
         test_command: command

--- a/lib/evilution/runner/baseline_runner.rb
+++ b/lib/evilution/runner/baseline_runner.rb
@@ -55,7 +55,11 @@ class Evilution::Runner::BaselineRunner
     return nil unless config.baseline? && subjects.any?
 
     log_start
-    baseline = Evilution::Baseline.new(timeout: config.timeout, **integration_class.baseline_options)
+    baseline = Evilution::Baseline.new(
+      timeout: config.timeout,
+      test_files: config.spec_files.empty? ? nil : config.spec_files,
+      **integration_class.baseline_options
+    )
     result = baseline.call(subjects)
     log_complete(result)
     result

--- a/spec/evilution/baseline_spec.rb
+++ b/spec/evilution/baseline_spec.rb
@@ -78,6 +78,47 @@ RSpec.describe Evilution::Baseline do
         .to output(%r{no matching test.*lib/user\.rb.*--spec}i).to_stderr
     end
 
+    context "with explicit test_files (from --spec flag)" do
+      # When the user passes --spec, they have told us which spec files cover
+      # the subjects. Baseline must run those spec files (and ONLY those) —
+      # never auto-discover or fall back to the full suite. Doing otherwise
+      # produces the misleading "No matching test found... Use --spec" warning
+      # users have reported even though they did pass --spec, and causes
+      # baseline to run unrelated specs that may fail for environment reasons,
+      # cascading into wrong score reporting.
+      subject(:baseline) do
+        described_class.new(
+          spec_resolver: spec_resolver, timeout: 5,
+          test_files: ["spec/explicit_spec.rb"]
+        )
+      end
+
+      it "runs the explicit spec files and skips auto-discovery" do
+        allow(baseline).to receive(:run_spec_file).with("spec/explicit_spec.rb").and_return(true)
+
+        baseline.call([subject1, subject3])
+
+        expect(baseline).to have_received(:run_spec_file).with("spec/explicit_spec.rb").once
+        expect(baseline).not_to have_received(:run_spec_file).with("spec/user_spec.rb")
+        expect(baseline).not_to have_received(:run_spec_file).with("spec/order_spec.rb")
+      end
+
+      it "does not fire the 'No matching test found' warning when test_files is provided" do
+        allow(baseline).to receive(:run_spec_file).with("spec/explicit_spec.rb").and_return(true)
+
+        expect { baseline.call([subject1]) }
+          .not_to output(/no matching test/i).to_stderr
+      end
+
+      it "reports failed explicit spec files" do
+        allow(baseline).to receive(:run_spec_file).with("spec/explicit_spec.rb").and_return(false)
+
+        result = baseline.call([subject1])
+
+        expect(result.failed_spec_files).to contain_exactly("spec/explicit_spec.rb")
+      end
+    end
+
     it "records duration" do
       allow(baseline).to receive(:run_spec_file).and_return(true)
 

--- a/spec/evilution/integration/rspec/result_builder_spec.rb
+++ b/spec/evilution/integration/rspec/result_builder_spec.rb
@@ -79,9 +79,9 @@ RSpec.describe Evilution::Integration::RSpec::ResultBuilder do
     # examples (spec file failed to load, --spec ignored, fail_if_no_examples
     # active, etc.), there is no evidence the mutation was caught — calling
     # that "killed" silently produces wrong scores. Surface it as :error.
-    context "when status nonzero AND zero examples executed" do
+    context "when status nonzero AND zero examples loaded" do
       it "returns an error hash (so classify_status reports :error, not :killed)" do
-        result = builder.from_run(2, "rspec args", detector, examples_executed: 0)
+        result = builder.from_run(2, "rspec args", detector, examples_loaded: 0)
 
         expect(result[:passed]).to be false
         expect(result[:error]).to match(/0 examples|no examples ran/i)
@@ -95,19 +95,19 @@ RSpec.describe Evilution::Integration::RSpec::ResultBuilder do
         allow(detector).to receive(:unique_crash_classes).and_return(["LoadError"])
         allow(detector).to receive(:crash_summary).and_return("LoadError x1")
 
-        result = builder.from_run(1, "rspec args", detector, examples_executed: 0)
+        result = builder.from_run(1, "rspec args", detector, examples_loaded: 0)
 
         expect(result[:test_crashed]).to be true
         expect(result[:error_class]).to eq("LoadError")
       end
     end
 
-    it "keeps plain fail behavior when examples_executed is positive" do
-      result = builder.from_run(1, "rspec args", detector, examples_executed: 3)
+    it "keeps plain fail behavior when examples_loaded is positive" do
+      result = builder.from_run(1, "rspec args", detector, examples_loaded: 3)
       expect(result).to eq({ passed: false, test_command: "rspec args" })
     end
 
-    it "keeps plain fail behavior when examples_executed is nil (back-compat)" do
+    it "keeps plain fail behavior when examples_loaded is nil (back-compat)" do
       result = builder.from_run(1, "rspec args", detector)
       expect(result).to eq({ passed: false, test_command: "rspec args" })
     end

--- a/spec/evilution/integration/rspec/result_builder_spec.rb
+++ b/spec/evilution/integration/rspec/result_builder_spec.rb
@@ -72,5 +72,44 @@ RSpec.describe Evilution::Integration::RSpec::ResultBuilder do
       result = builder.from_run(1, "rspec args", detector)
       expect(result).to eq({ passed: false, test_command: "rspec args" })
     end
+
+    # Bug B (EV-720r): user reported all mutations marked `killed=100%` on
+    # macOS Rails. Root cause is classify_status defaulting to :killed for any
+    # nonzero RSpec exit. If RSpec returns nonzero because it loaded ZERO
+    # examples (spec file failed to load, --spec ignored, fail_if_no_examples
+    # active, etc.), there is no evidence the mutation was caught — calling
+    # that "killed" silently produces wrong scores. Surface it as :error.
+    context "when status nonzero AND zero examples executed" do
+      it "returns an error hash (so classify_status reports :error, not :killed)" do
+        result = builder.from_run(2, "rspec args", detector, examples_executed: 0)
+
+        expect(result[:passed]).to be false
+        expect(result[:error]).to match(/0 examples|no examples ran/i)
+        expect(result[:test_command]).to eq("rspec args")
+      end
+
+      it "still surfaces crashes when only_crashes? is true, even with 0 examples" do
+        # Crash signal is stronger than the zero-examples heuristic; keep
+        # current behavior.
+        allow(detector).to receive(:only_crashes?).and_return(true)
+        allow(detector).to receive(:unique_crash_classes).and_return(["LoadError"])
+        allow(detector).to receive(:crash_summary).and_return("LoadError x1")
+
+        result = builder.from_run(1, "rspec args", detector, examples_executed: 0)
+
+        expect(result[:test_crashed]).to be true
+        expect(result[:error_class]).to eq("LoadError")
+      end
+    end
+
+    it "keeps plain fail behavior when examples_executed is positive" do
+      result = builder.from_run(1, "rspec args", detector, examples_executed: 3)
+      expect(result).to eq({ passed: false, test_command: "rspec args" })
+    end
+
+    it "keeps plain fail behavior when examples_executed is nil (back-compat)" do
+      result = builder.from_run(1, "rspec args", detector)
+      expect(result).to eq({ passed: false, test_command: "rspec args" })
+    end
   end
 end

--- a/spec/evilution/integration/rspec_spec.rb
+++ b/spec/evilution/integration/rspec_spec.rb
@@ -58,6 +58,34 @@ RSpec.describe Evilution::Integration::RSpec do
       expect(result[:passed]).to be true
     end
 
+    # EV-720r: distinguish "RSpec ran examples and they failed → killed" from
+    # "RSpec exited nonzero but loaded zero examples → no observation". The
+    # second case must surface as :error so it cannot silently inflate kill
+    # counts. world.example_count is the count of loaded examples after the
+    # run; zero indicates the spec file failed to load (autoload error,
+    # missing dependency, etc.).
+    it "returns an error result when rspec exits nonzero AND no examples loaded" do
+      allow(RSpec::Core::Runner).to receive(:run).and_return(1)
+      allow(RSpec.world).to receive(:example_count).and_return(0)
+
+      result = integration.call(mutation)
+
+      expect(result[:passed]).to be false
+      expect(result[:error]).to match(/0 examples|no examples/i)
+    end
+
+    it "treats nonzero exit with loaded examples as a real test failure" do
+      # If at least one example was loaded and ran, nonzero exit means the
+      # test caught the mutation. Do NOT downgrade this to :error.
+      allow(RSpec::Core::Runner).to receive(:run).and_return(1)
+      allow(RSpec.world).to receive(:example_count).and_return(3)
+
+      result = integration.call(mutation)
+
+      expect(result[:passed]).to be false
+      expect(result[:error]).to be_nil
+    end
+
     it "restores the original file even when runner raises" do
       allow(RSpec::Core::Runner).to receive(:run).and_raise("boom")
 


### PR DESCRIPTION
… no examples loaded

- Update `Evilution::Baseline` to accept explicit test files via `--spec` flag.
- Modify `Evilution::Integration::RSpec::ResultBuilder` to handle cases where RSpec exits nonzero but loads zero examples, preventing incorrect mutation kill counts.
- Enhance tests to verify behavior when explicit test files are provided and when no examples are loaded.