### PR TITLE
Implement worker process group management and signal forwarding

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -415,3 +415,4 @@
 {"id":"int-c295efed","kind":"field_change","created_at":"2026-06-06T03:56:26.595461244Z","actor":"Denis Kiselev","issue_id":"EV-gl1e","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-552b93f8","kind":"field_change","created_at":"2026-06-06T06:34:06.544071647Z","actor":"Denis Kiselev","issue_id":"EV-cnx8","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}
 {"id":"int-38e50f55","kind":"field_change","created_at":"2026-06-06T06:34:58.433491242Z","actor":"Denis Kiselev","issue_id":"EV-gl1e","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Merged via PR #1329"}}
+{"id":"int-121d6c46","kind":"field_change","created_at":"2026-06-06T07:31:53.274033616Z","actor":"Denis Kiselev","issue_id":"EV-cnx8","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Merged via PR #1331"}}

--- a/lib/evilution/parallel/work_queue/worker.rb
+++ b/lib/evilution/parallel/work_queue/worker.rb
@@ -27,10 +27,18 @@ class Evilution::Parallel::WorkQueue::Worker
 
     cmd_read.close
     res_write.close
-    # Only register the pgid when isolation took: an unisolated worker stays in
-    # the parent's group and already receives the terminal SIGINT/SIGTERM, so
-    # the trap must not also kill(-pid) -- pid is not a group leader there.
-    Evilution::Parallel::WorkQueue::WorkerRegistry.register(pid) if isolate_process_group(pid)
+    # Register BEFORE isolating so the trap can never observe a worker that is
+    # already its own group leader yet missing from the registry (EV-jwao race,
+    # GH #1333 review): the spawn runs on the same main thread the trap
+    # interrupts, so a signal arriving between setpgid and register would
+    # otherwise leak a leader the trap cannot reach. Ordering register first
+    # leaves only safe windows -- pre-setpgid the child still shares the parent
+    # group and receives the terminal signal directly; once it is its own
+    # leader the registry already lists it. Registering unconditionally is safe
+    # because signal_all's kill(-pid) is a no-op (Errno::ESRCH) for a pid that
+    # never became a group leader (setpgid failed).
+    Evilution::Parallel::WorkQueue::WorkerRegistry.register(pid)
+    isolate_process_group(pid)
     new(pid:, cmd_write:, res_read:, worker_index:)
   end
 
@@ -40,20 +48,15 @@ class Evilution::Parallel::WorkQueue::Worker
   # worker, that grandchild must die with it rather than orphan to init holding
   # memory/fds/connections. Done parent-side (before the child forks anything)
   # so a failure is visible here instead of being swallowed in the child.
-  #
-  # Returns true when the worker is now its own group leader, false otherwise --
-  # the caller registers the pgid for signal forwarding (EV-jwao) only on true.
   def self.isolate_process_group(pid)
     Process.setpgid(pid, pid)
-    true
   rescue Errno::EACCES, Errno::ESRCH
     # EACCES: child already exec'd/changed group; ESRCH: child already exited.
     # Both are benign -- reaping handles the child either way.
-    false
+    nil
   rescue SystemCallError => e
     warn "evilution: could not isolate worker #{pid} into its own process " \
          "group (#{e.class}: #{e.message}); grandchildren may survive a kill."
-    false
   end
 
   # EV-kdns / GH #817: translate 0-based worker slot to parallel_tests'

--- a/lib/evilution/parallel/work_queue/worker.rb
+++ b/lib/evilution/parallel/work_queue/worker.rb
@@ -4,6 +4,7 @@ require_relative "../work_queue"
 require_relative "../../child_output"
 require_relative "channel"
 require_relative "channel/frame"
+require_relative "worker_registry"
 
 class Evilution::Parallel::WorkQueue::Worker
   Timing = Data.define(:busy, :wall)
@@ -26,7 +27,10 @@ class Evilution::Parallel::WorkQueue::Worker
 
     cmd_read.close
     res_write.close
-    isolate_process_group(pid)
+    # Only register the pgid when isolation took: an unisolated worker stays in
+    # the parent's group and already receives the terminal SIGINT/SIGTERM, so
+    # the trap must not also kill(-pid) -- pid is not a group leader there.
+    Evilution::Parallel::WorkQueue::WorkerRegistry.register(pid) if isolate_process_group(pid)
     new(pid:, cmd_write:, res_read:, worker_index:)
   end
 
@@ -36,15 +40,20 @@ class Evilution::Parallel::WorkQueue::Worker
   # worker, that grandchild must die with it rather than orphan to init holding
   # memory/fds/connections. Done parent-side (before the child forks anything)
   # so a failure is visible here instead of being swallowed in the child.
+  #
+  # Returns true when the worker is now its own group leader, false otherwise --
+  # the caller registers the pgid for signal forwarding (EV-jwao) only on true.
   def self.isolate_process_group(pid)
     Process.setpgid(pid, pid)
+    true
   rescue Errno::EACCES, Errno::ESRCH
     # EACCES: child already exec'd/changed group; ESRCH: child already exited.
     # Both are benign -- reaping handles the child either way.
-    nil
+    false
   rescue SystemCallError => e
     warn "evilution: could not isolate worker #{pid} into its own process " \
          "group (#{e.class}: #{e.message}); grandchildren may survive a kill."
+    false
   end
 
   # EV-kdns / GH #817: translate 0-based worker slot to parallel_tests'
@@ -112,6 +121,10 @@ class Evilution::Parallel::WorkQueue::Worker
     Process.wait(@pid)
   rescue Errno::ECHILD
     nil
+  ensure
+    # Drop the pgid once the leader is reaped so the trap never signals a group
+    # whose pid the OS may have recycled. No-op if it was never registered.
+    Evilution::Parallel::WorkQueue::WorkerRegistry.unregister(@pid)
   end
 
   def retire

--- a/lib/evilution/parallel/work_queue/worker_registry.rb
+++ b/lib/evilution/parallel/work_queue/worker_registry.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "../work_queue"
+
+# Process-global registry of live worker process-group ids (pgids).
+#
+# EV-jwao / GH #1332: EV-cnx8 made each Worker its own process-group leader so a
+# stuck worker's whole subtree can be group-killed. Side effect: a terminal
+# Ctrl-C delivers SIGINT only to the parent's foreground group, so workers (now
+# in their own groups) no longer receive it -- and the parent's fatal-signal
+# death skips work_queue#map's `ensure cleanup_workers`, leaking any worker that
+# was actively running a (possibly blocking) mutation at interrupt time.
+#
+# Runner#install_signal_handler reads this registry from inside the trap and
+# forwards INT/TERM to each worker group before re-raising to DEFAULT.
+#
+# Signal-safety: under MRI a trap handler runs on the main thread between VM
+# instructions, so it must not acquire a Mutex (the main thread may hold it ->
+# deadlock). register/unregister therefore swap @pgids for a freshly built
+# frozen array via a single atomic reference assignment (copy-on-write). The
+# trap reads the current reference once and iterates that complete, immutable
+# snapshot -- no torn reads, no lock.
+module Evilution::Parallel::WorkQueue::WorkerRegistry
+  @pgids = [].freeze
+
+  class << self
+    # Frozen snapshot. Safe to read from a signal handler.
+    attr_reader :pgids
+
+    def register(pgid)
+      @pgids = (@pgids + [pgid]).freeze
+    end
+
+    def unregister(pgid)
+      @pgids = @pgids.reject { |existing| existing == pgid }.freeze
+    end
+
+    def signal_all(sig)
+      @pgids.each do |pgid|
+        Process.kill(sig, -pgid)
+      rescue Errno::ESRCH
+        # Group already gone (worker + subtree reaped) -- nothing to signal.
+        nil
+      end
+    end
+  end
+end

--- a/lib/evilution/runner.rb
+++ b/lib/evilution/runner.rb
@@ -178,6 +178,11 @@ class Evilution::Runner
   def install_signal_handler(sig)
     prev_handler = Signal.trap(sig) do
       Evilution::TempDirTracker.cleanup_all
+      # EV-jwao / GH #1332: workers are their own process-group leaders, so a
+      # terminal Ctrl-C reaches only the parent's group. Forward to each worker
+      # group here -- the parent's fatal-signal death skips work_queue#map's
+      # `ensure cleanup_workers`, so this trap is the reliable forwarding hook.
+      Evilution::Parallel::WorkQueue::WorkerRegistry.signal_all(sig)
 
       case prev_handler
       when Proc, Method
@@ -226,6 +231,7 @@ require_relative "result/summary"
 require_relative "baseline"
 require_relative "cache"
 require_relative "parallel/pool"
+require_relative "parallel/work_queue/worker_registry"
 require_relative "session/store"
 require_relative "temp_dir_tracker"
 require_relative "rails_detector"

--- a/spec/evilution/parallel/work_queue/interrupt_forwarding_spec.rb
+++ b/spec/evilution/parallel/work_queue/interrupt_forwarding_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "timeout"
+require "tmpdir"
+require "evilution/runner"
+require "evilution/parallel/work_queue/worker"
+require "evilution/parallel/work_queue/worker/loop"
+require "evilution/parallel/work_queue/worker_registry"
+
+# EV-jwao / GH #1332: end-to-end proof that a terminal interrupt is forwarded to
+# worker process groups so an actively-busy worker (and the grandchildren it
+# forked) does not leak when the parent dies via the fatal-signal path that
+# skips work_queue#map's `ensure cleanup_workers`.
+RSpec.describe "Interrupt forwarding to busy worker groups" do
+  def process_alive?(pid)
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
+  rescue Errno::EPERM
+    true
+  end
+
+  def wait_until(timeout: 8)
+    Timeout.timeout(timeout) do
+      sleep(0.05) until yield
+    end
+  end
+
+  it "kills the busy worker subtree when the parent is interrupted" do
+    Dir.mktmpdir do |dir|
+      ready_file = File.join(dir, "ready")
+      gpid_file = File.join(dir, "grandchild.pid")
+      gpid = nil
+
+      parent_pid = fork do
+        # Fresh signal disposition so install_signal_handler chains to DEFAULT
+        # (the fatal-signal path that skips the ensure cleanup).
+        Signal.trap("TERM", "DEFAULT")
+        Evilution::Runner.new(config: Evilution::Config.new(skip_config_file: true))
+                         .send(:install_signal_handler, "TERM")
+
+        worker = Evilution::Parallel::WorkQueue::Worker.spawn(worker_index: 0, hooks: nil) do |_item|
+          grandchild = fork { sleep 60 }
+          File.write(gpid_file, grandchild.to_s)
+          sleep 60
+        end
+        worker.send_item(0, :go)
+
+        File.write(ready_file, "1")
+        sleep 60
+      end
+
+      begin
+        wait_until { File.exist?(ready_file) }
+        wait_until { File.exist?(gpid_file) && !File.empty?(gpid_file) }
+        gpid = File.read(gpid_file).to_i
+        expect(process_alive?(gpid)).to be(true)
+
+        Process.kill("TERM", parent_pid)
+
+        status =
+          begin
+            Timeout.timeout(8) { Process.wait2(parent_pid).last }
+          rescue Timeout::Error
+            Process.kill("KILL", parent_pid)
+            Process.wait2(parent_pid).last
+          end
+        expect(status.signaled?).to be(true)
+
+        # The grandchild was in the worker's forwarded group, so it must be gone.
+        wait_until { !process_alive?(gpid) }
+        expect(process_alive?(gpid)).to be(false)
+      ensure
+        begin
+          Process.kill("KILL", gpid) if gpid && process_alive?(gpid)
+        rescue Errno::ESRCH
+          nil
+        end
+      end
+    end
+  end
+end

--- a/spec/evilution/parallel/work_queue/worker_registry_spec.rb
+++ b/spec/evilution/parallel/work_queue/worker_registry_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "evilution/parallel/work_queue/worker_registry"
+
+RSpec.describe Evilution::Parallel::WorkQueue::WorkerRegistry do
+  around do |example|
+    snapshot = described_class.pgids
+    snapshot.each { |pgid| described_class.unregister(pgid) }
+    example.run
+    described_class.pgids.each { |pgid| described_class.unregister(pgid) }
+    snapshot.each { |pgid| described_class.register(pgid) }
+  end
+
+  describe ".register / .pgids" do
+    it "starts empty in an isolated registry" do
+      expect(described_class.pgids).to eq([])
+    end
+
+    it "records a registered pgid" do
+      described_class.register(4242)
+      expect(described_class.pgids).to contain_exactly(4242)
+    end
+
+    it "records multiple pgids in registration order" do
+      described_class.register(10)
+      described_class.register(20)
+      described_class.register(30)
+      expect(described_class.pgids).to eq([10, 20, 30])
+    end
+
+    it "exposes pgids as a frozen snapshot" do
+      described_class.register(99)
+      expect(described_class.pgids).to be_frozen
+    end
+
+    it "returns an independent snapshot that does not mutate the registry" do
+      described_class.register(1)
+      snapshot = described_class.pgids
+      described_class.register(2)
+      expect(snapshot).to eq([1])
+    end
+  end
+
+  describe ".unregister" do
+    it "removes a registered pgid" do
+      described_class.register(7)
+      described_class.register(8)
+      described_class.unregister(7)
+      expect(described_class.pgids).to contain_exactly(8)
+    end
+
+    it "is a no-op when the pgid was never registered" do
+      described_class.register(5)
+      expect { described_class.unregister(999) }.not_to change(described_class, :pgids)
+    end
+
+    it "removes every occurrence of a duplicated pgid" do
+      described_class.register(3)
+      described_class.register(3)
+      described_class.unregister(3)
+      expect(described_class.pgids).to eq([])
+    end
+  end
+
+  describe ".signal_all" do
+    it "sends the signal to the negated pgid of every registered group" do
+      allow(Process).to receive(:kill)
+      described_class.register(11)
+      described_class.register(22)
+
+      described_class.signal_all("TERM")
+
+      expect(Process).to have_received(:kill).with("TERM", -11)
+      expect(Process).to have_received(:kill).with("TERM", -22)
+    end
+
+    it "swallows Errno::ESRCH for an already-dead group and continues" do
+      allow(Process).to receive(:kill).with("INT", -1).and_raise(Errno::ESRCH)
+      allow(Process).to receive(:kill).with("INT", -2)
+      described_class.register(1)
+      described_class.register(2)
+
+      expect { described_class.signal_all("INT") }.not_to raise_error
+      expect(Process).to have_received(:kill).with("INT", -2)
+    end
+
+    it "does nothing when no workers are registered" do
+      allow(Process).to receive(:kill)
+      described_class.signal_all("INT")
+      expect(Process).not_to have_received(:kill)
+    end
+  end
+end

--- a/spec/evilution/parallel/work_queue/worker_spec.rb
+++ b/spec/evilution/parallel/work_queue/worker_spec.rb
@@ -4,8 +4,18 @@ require "spec_helper"
 require "timeout"
 require "evilution/parallel/work_queue/worker"
 require "evilution/parallel/work_queue/worker/loop"
+require "evilution/parallel/work_queue/worker_registry"
 
 RSpec.describe Evilution::Parallel::WorkQueue::Worker do
+  let(:registry) { Evilution::Parallel::WorkQueue::WorkerRegistry }
+
+  around do |example|
+    snapshot = Evilution::Parallel::WorkQueue::WorkerRegistry.pgids
+    snapshot.each { |pgid| Evilution::Parallel::WorkQueue::WorkerRegistry.unregister(pgid) }
+    example.run
+    Evilution::Parallel::WorkQueue::WorkerRegistry.pgids.each { |pgid| Evilution::Parallel::WorkQueue::WorkerRegistry.unregister(pgid) }
+    snapshot.each { |pgid| Evilution::Parallel::WorkQueue::WorkerRegistry.register(pgid) }
+  end
   def process_alive?(pid)
     Process.kill(0, pid)
     true
@@ -282,6 +292,45 @@ RSpec.describe Evilution::Parallel::WorkQueue::Worker do
       worker.close_pipes
       worker.reap
       expect { worker.kill }.not_to raise_error
+    end
+  end
+
+  describe "WorkerRegistry integration" do
+    it "registers the worker pgid on spawn" do
+      worker = described_class.spawn(worker_index: 0, hooks: nil) { |x| x }
+      begin
+        expect(registry.pgids).to include(worker.pid)
+      ensure
+        worker.shutdown
+        worker.close_pipes
+        worker.reap
+      end
+    end
+
+    it "deregisters the worker pgid on reap" do
+      worker = described_class.spawn(worker_index: 0, hooks: nil) { |x| x }
+      worker.shutdown
+      worker.close_pipes
+      worker.reap
+      expect(registry.pgids).not_to include(worker.pid)
+    end
+
+    it "deregisters the worker pgid on retire" do
+      worker = described_class.spawn(worker_index: 0, hooks: nil) { |x| x }
+      worker.retire
+      expect(registry.pgids).not_to include(worker.pid)
+    end
+
+    it "does not register a pgid when process-group isolation fails" do
+      allow(described_class).to receive(:isolate_process_group).and_return(false)
+      worker = described_class.spawn(worker_index: 0, hooks: nil) { |x| x }
+      begin
+        expect(registry.pgids).not_to include(worker.pid)
+      ensure
+        worker.shutdown
+        worker.close_pipes
+        worker.reap
+      end
     end
   end
 

--- a/spec/evilution/parallel/work_queue/worker_spec.rb
+++ b/spec/evilution/parallel/work_queue/worker_spec.rb
@@ -321,11 +321,15 @@ RSpec.describe Evilution::Parallel::WorkQueue::Worker do
       expect(registry.pgids).not_to include(worker.pid)
     end
 
-    it "does not register a pgid when process-group isolation fails" do
-      allow(described_class).to receive(:isolate_process_group).and_return(false)
+    it "registers the worker pgid before isolating it (no leader-but-unregistered window)" do
+      # The trap forwards only to registered pgids; registering before setpgid
+      # guarantees a worker is never its own group leader while absent from the
+      # registry. Proven by registration happening even if isolation is a no-op.
+      allow(described_class).to receive(:isolate_process_group)
       worker = described_class.spawn(worker_index: 0, hooks: nil) { |x| x }
       begin
-        expect(registry.pgids).not_to include(worker.pid)
+        expect(registry.pgids).to include(worker.pid)
+        expect(described_class).to have_received(:isolate_process_group).with(worker.pid)
       ensure
         worker.shutdown
         worker.close_pipes

--- a/spec/evilution/runner_spec.rb
+++ b/spec/evilution/runner_spec.rb
@@ -2880,6 +2880,19 @@ RSpec.describe Evilution::Runner do
         expect(chained).to be(true)
       end
 
+      it "forwards the signal to live worker process groups when fired" do
+        Signal.trap("INT") { nil }
+
+        runner.send(:install_signal_handler, "INT")
+
+        allow(Evilution::TempDirTracker).to receive(:cleanup_all)
+        allow(Evilution::Parallel::WorkQueue::WorkerRegistry).to receive(:signal_all)
+        handler = Signal.trap("INT", "DEFAULT")
+        handler.call
+
+        expect(Evilution::Parallel::WorkQueue::WorkerRegistry).to have_received(:signal_all).with("INT")
+      end
+
       it "re-raises the signal with the default disposition when there was no prior Ruby handler" do
         require "timeout"
         reader, writer = IO.pipe


### PR DESCRIPTION
- Introduced WorkerRegistry to manage live worker process-group IDs.
- Updated Worker class to register and unregister process-group IDs.
- Enhanced signal handling in Runner to forward signals to worker groups.
- Added tests to verify signal forwarding and worker registration behavior.

Fixes #1332