### PR TITLE
Add shared operator primitives for nil mutation and child promotion

### DIFF
--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -448,3 +448,5 @@
 {"id":"int-616f39e1","kind":"field_change","created_at":"2026-07-15T13:33:53.68007233Z","actor":"Denis Kiselev","issue_id":"EV-y194","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-abcaeb3a","kind":"field_change","created_at":"2026-07-15T13:33:54.363899883Z","actor":"Denis Kiselev","issue_id":"EV-j2kz","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
 {"id":"int-b8027311","kind":"field_change","created_at":"2026-07-15T13:34:47.737536249Z","actor":"Denis Kiselev","issue_id":"EV-w07i","extra":{"field":"status","new_value":"closed","old_value":"open","reason":"Closed"}}
+{"id":"int-e7b1f137","kind":"field_change","created_at":"2026-08-14T05:36:05.821384373Z","actor":"Denis Kiselev","issue_id":"EV-4ild","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-c003e7fa","kind":"field_change","created_at":"2026-08-22T04:23:28.006710286Z","actor":"Denis Kiselev","issue_id":"EV-170m.1","extra":{"field":"status","new_value":"in_progress","old_value":"open"}}

--- a/lib/evilution/mutator/base.rb
+++ b/lib/evilution/mutator/base.rb
@@ -3,10 +3,13 @@
 require "prism"
 
 require_relative "../mutator"
+require_relative "primitives"
 require_relative "../integration/loading/body_call_neutralizer"
 require_relative "../ast/heredoc_span"
 
 class Evilution::Mutator::Base < Prism::Visitor
+  include Evilution::Mutator::Primitives
+
   AffectedSlices = Data.define(:original, :mutated)
   private_constant :AffectedSlices
 
@@ -41,7 +44,12 @@ class Evilution::Mutator::Base < Prism::Visitor
 
   private
 
-  def add_mutation(offset:, length:, replacement:, node:)
+  # `skip_unparseable` makes the mutation vanish rather than be recorded when
+  # the surgery does not parse. Off by default: the point operators rely on
+  # unparseable bytes reaching the reporter as their own bucket. The shared
+  # primitives opt in, since a nil-ification or promotion that does not parse
+  # carries no signal.
+  def add_mutation(offset:, length:, replacement:, node:, skip_unparseable: false)
     return if @filter && @filter.skip?(node)
 
     # When the byte range opens a heredoc but stops at its inline anchor,
@@ -67,6 +75,8 @@ class Evilution::Mutator::Base < Prism::Visitor
     surgery = Evilution::AST::SourceSurgeon.apply(
       @file_source, offset: offset, length: length, replacement: replacement
     )
+    return if skip_unparseable && surgery.unparseable?
+
     slices = slice_affected_lines(
       mutated_source: surgery.source,
       offset: offset,
@@ -74,7 +84,9 @@ class Evilution::Mutator::Base < Prism::Visitor
       replacement_bytesize: replacement.bytesize
     )
 
-    @mutations << build_mutation_record(node, surgery, slices)
+    mutation = build_mutation_record(node, surgery, slices)
+    @mutations << mutation
+    mutation
   end
 
   def build_mutation_record(node, surgery, slices)

--- a/lib/evilution/mutator/primitives.rb
+++ b/lib/evilution/mutator/primitives.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require_relative "../mutator"
+
+# Mutation shapes shared across the operator families: replacing an
+# expression with `nil`, and replacing an expression with the source of one
+# of its children. Both are built on Base#add_mutation, so the
+# equivalent-mutant filter and the heredoc-span guards still apply.
+#
+# Unlike a bare add_mutation call, these skip rather than emit when the
+# result would not parse in its surrounding context. A promotion that does
+# not parse is noise rather than signal, so it never reaches the
+# `unparseable` bucket the point operators still populate.
+module Evilution::Mutator::Primitives
+  private
+
+  # Replace `target`'s byte span with `nil`, attributing the mutation to
+  # `node`. `target` defaults to `node`; pass an inner node to nil out a body
+  # while keeping the reported location on the enclosing construct.
+  def mutate_to_nil(node, target: node)
+    replace_span(node: node, target: target, replacement: "nil")
+  end
+
+  # Replace `target`'s byte span with `child`'s source, verbatim. `child` may
+  # be nil — Prism leaves optional slots (a call's receiver, an if's else)
+  # empty — in which case there is nothing to promote.
+  def promote_child(node, child, target: node)
+    return nil if child.nil?
+
+    replace_span(node: node, target: target, replacement: source_of(child))
+  end
+
+  def replace_span(node:, target:, replacement:)
+    return nil if target.nil?
+
+    location = target.location
+    return nil if replacement == byteslice_source(location.start_offset, location.length)
+
+    add_mutation(
+      offset: location.start_offset,
+      length: location.length,
+      replacement: replacement,
+      node: node,
+      skip_unparseable: true
+    )
+  end
+
+  def source_of(child)
+    location = child.location
+    byteslice_source(location.start_offset, location.length)
+  end
+end

--- a/spec/evilution/mutator/base_spec.rb
+++ b/spec/evilution/mutator/base_spec.rb
@@ -246,6 +246,62 @@ RSpec.describe Evilution::Mutator::Base do
     end
   end
 
+  describe "#add_mutation skip_unparseable" do
+    let(:source) { "def foo(a)\n  a\nend\n" }
+    let(:node) { Prism.parse(source).value.statements.body.first }
+
+    def build_operator
+      operator = described_class.new
+      operator.instance_variable_set(:@file_source, source)
+      operator.instance_variable_set(:@filter, nil)
+      operator.instance_variable_set(:@subject, double("Subject", file_path: "x.rb"))
+      operator
+    end
+
+    it "keeps an unparseable mutation by default" do
+      operator = build_operator
+
+      operator.send(:add_mutation, offset: 8, length: 1, replacement: "nil", node: node)
+
+      expect(operator.mutations.map(&:parse_status)).to eq([:unparseable])
+    end
+
+    it "drops an unparseable mutation when skip_unparseable is true" do
+      operator = build_operator
+
+      operator.send(:add_mutation, offset: 8, length: 1, replacement: "nil", node: node,
+                                   skip_unparseable: true)
+
+      expect(operator.mutations).to be_empty
+    end
+
+    it "keeps a parseable mutation when skip_unparseable is true" do
+      operator = build_operator
+
+      operator.send(:add_mutation, offset: 13, length: 1, replacement: "nil", node: node,
+                                   skip_unparseable: true)
+
+      expect(operator.mutations.map(&:parse_status)).to eq([:ok])
+    end
+
+    it "returns the mutation it recorded" do
+      operator = build_operator
+
+      result = operator.send(:add_mutation, offset: 13, length: 1, replacement: "nil", node: node)
+
+      expect(result).to eq(operator.mutations.first)
+    end
+
+    it "returns nil when the mutation is skipped" do
+      operator = build_operator
+
+      result = operator.send(:add_mutation, offset: 8, length: 1, replacement: "nil", node: node,
+                                            skip_unparseable: true)
+
+      expect(result).to be_nil
+    end
+  end
+
   describe "#build_eval_source" do
     let(:operator) do
       op = described_class.new

--- a/spec/evilution/mutator/primitives_spec.rb
+++ b/spec/evilution/mutator/primitives_spec.rb
@@ -1,0 +1,184 @@
+# frozen_string_literal: true
+
+RSpec.describe Evilution::Mutator::Primitives do
+  # Each example drives an anonymous Mutator::Base subclass so the primitives
+  # are exercised through the same path a real operator uses: visit the node,
+  # call the helper, let Base build the record.
+  def mutations_for(code, &operator_body)
+    Tempfile.create(["primitives", ".rb"]) do |file|
+      file.write(code)
+      file.flush
+
+      node = Prism.parse(code).value.statements.body.first
+      subject = Evilution::Subject.new(
+        name: "Test#m", file_path: file.path, line_number: 1, source: code, node: node
+      )
+
+      Class.new(Evilution::Mutator::Base, &operator_body).new.call(subject)
+    end
+  end
+
+  describe "#mutate_to_nil" do
+    it "replaces the node's own span with nil" do
+      muts = mutations_for("a && b") do
+        def visit_and_node(node)
+          mutate_to_nil(node)
+          super
+        end
+      end
+
+      expect(muts.map(&:mutated_source)).to eq(["nil"])
+    end
+
+    it "overwrites the target's span when target is given" do
+      muts = mutations_for("if x\n  y\nend") do
+        def visit_if_node(node)
+          mutate_to_nil(node, target: node.statements)
+          super
+        end
+      end
+
+      expect(muts.first.mutated_source).to eq("if x\n  nil\nend")
+    end
+
+    it "attributes the mutation to the node, not the target" do
+      muts = mutations_for("if x\n  y\nend") do
+        def visit_if_node(node)
+          mutate_to_nil(node, target: node.statements)
+          super
+        end
+      end
+
+      expect(muts.first.line).to eq(1)
+    end
+
+    it "skips when the target span is already nil" do
+      muts = mutations_for("nil") do
+        def visit_nil_node(node)
+          mutate_to_nil(node)
+          super
+        end
+      end
+
+      expect(muts).to be_empty
+    end
+
+    it "skips when the target is absent" do
+      muts = mutations_for("if x\nend") do
+        def visit_if_node(node)
+          mutate_to_nil(node, target: node.statements)
+          super
+        end
+      end
+
+      expect(muts).to be_empty
+    end
+
+    it "skips when the result does not parse in its surrounding context" do
+      muts = mutations_for("def foo(a)\n  a\nend") do
+        def visit_required_parameter_node(node)
+          mutate_to_nil(node)
+          super
+        end
+      end
+
+      expect(muts).to be_empty
+    end
+
+    it "still honours the equivalent-mutant filter" do
+      filter = Evilution::AST::Pattern::Filter.new(["call{name=log}"])
+      code = "log()"
+
+      muts = Tempfile.create(["primitives", ".rb"]) do |file|
+        file.write(code)
+        file.flush
+
+        node = Prism.parse(code).value.statements.body.first
+        subject = Evilution::Subject.new(
+          name: "Test#m", file_path: file.path, line_number: 1, source: code, node: node
+        )
+        operator = Class.new(Evilution::Mutator::Base) do
+          def visit_call_node(node)
+            mutate_to_nil(node)
+            super
+          end
+        end.new
+
+        operator.call(subject, filter: filter)
+      end
+
+      expect(muts).to be_empty
+      expect(filter.skipped_count).to eq(1)
+    end
+  end
+
+  describe "#promote_child" do
+    it "replaces the node's span with the child's source" do
+      muts = mutations_for("a && b") do
+        def visit_and_node(node)
+          promote_child(node, node.left)
+          super
+        end
+      end
+
+      expect(muts.map(&:mutated_source)).to eq(["a"])
+    end
+
+    it "copies the child's source verbatim, including its own punctuation" do
+      muts = mutations_for("a && (b + c)") do
+        def visit_and_node(node)
+          promote_child(node, node.right)
+          super
+        end
+      end
+
+      expect(muts.map(&:mutated_source)).to eq(["(b + c)"])
+    end
+
+    it "overwrites the target's span when target is given" do
+      muts = mutations_for("if x\n  a && b\nend") do
+        def visit_and_node(node)
+          promote_child(node, node.right, target: node)
+          super
+        end
+      end
+
+      expect(muts.first.mutated_source).to eq("if x\n  b\nend")
+    end
+
+    it "skips when the child is absent" do
+      muts = mutations_for("foo") do
+        def visit_call_node(node)
+          promote_child(node, node.receiver)
+          super
+        end
+      end
+
+      expect(muts).to be_empty
+    end
+
+    it "skips when the child's source is byte-identical to the target span" do
+      muts = mutations_for("if x\n  y\nend") do
+        def visit_if_node(node)
+          promote_child(node.statements, node.statements.body.first)
+          super
+        end
+      end
+
+      expect(muts).to be_empty
+    end
+
+    it "skips when the promoted child does not parse in its surrounding context" do
+      muts = mutations_for("foo(*a)") do
+        def visit_call_node(node)
+          return super if node.arguments.nil?
+
+          promote_child(node, node.arguments.arguments.first)
+          super
+        end
+      end
+
+      expect(muts).to be_empty
+    end
+  end
+end

--- a/spec/evilution/mutator/primitives_spec.rb
+++ b/spec/evilution/mutator/primitives_spec.rb
@@ -137,13 +137,26 @@ RSpec.describe Evilution::Mutator::Primitives do
 
     it "overwrites the target's span when target is given" do
       muts = mutations_for("if x\n  a && b\nend") do
-        def visit_and_node(node)
-          promote_child(node, node.right, target: node)
+        def visit_if_node(node)
+          and_node = node.statements.body.first
+          promote_child(node, and_node.right, target: node.statements)
           super
         end
       end
 
       expect(muts.first.mutated_source).to eq("if x\n  b\nend")
+    end
+
+    it "attributes the mutation to the node, not the target" do
+      muts = mutations_for("if x\n  a && b\nend") do
+        def visit_if_node(node)
+          and_node = node.statements.body.first
+          promote_child(node, and_node.right, target: node.statements)
+          super
+        end
+      end
+
+      expect(muts.first.line).to eq(1)
     end
 
     it "skips when the child is absent" do


### PR DESCRIPTION
- Introduced `Evilution::Mutator::Primitives` module with methods to mutate nodes to nil and promote child nodes.
- Updated `add_mutation` method to support skipping unparseable mutations.
- Enhanced tests for mutation behavior with new primitives.