### PR TITLE
Enhance ConcernStateCleaner to handle ActiveSupport deprecation proxy…

### DIFF
--- a/lib/evilution/integration/loading/concern_state_cleaner.rb
+++ b/lib/evilution/integration/loading/concern_state_cleaner.rb
@@ -11,6 +11,22 @@ require_relative "../../load_path/subpath_resolver"
 class Evilution::Integration::Loading::ConcernStateCleaner
   IVARS = %i[@_included_block @_prepended_block].freeze
 
+  # ObjectSpace hands us every Module in the VM, including ones that answer no
+  # message honestly. ActiveSupport::Deprecation::DeprecatedConstantProxy
+  # subclasses Module and undefines all of its instance methods, so a plain
+  # `mod.singleton_class` lands in its method_missing and emits the
+  # deprecation; where the deprecator's behaviour is :raise (grape's
+  # spec_helper sets that), the sweep blows up on a module it merely walked
+  # past. Calling through UnboundMethods bypasses the object's own method
+  # table, so a proxy is never given the chance to intercept -- and this holds
+  # for any method_missing-based wrapper, not just ActiveSupport's.
+  # EV-v2rc / GH #1581.
+  SINGLETON_CLASS = Object.instance_method(:singleton_class)
+  IVAR_DEFINED = Object.instance_method(:instance_variable_defined?)
+  IVAR_GET = Object.instance_method(:instance_variable_get)
+  REMOVE_IVAR = Object.instance_method(:remove_instance_variable)
+  private_constant :SINGLETON_CLASS, :IVAR_DEFINED, :IVAR_GET, :REMOVE_IVAR
+
   def initialize(subpath_resolver: Evilution::LoadPath::SubpathResolver.new)
     @subpath_resolver = subpath_resolver
   end
@@ -22,7 +38,7 @@ class Evilution::Integration::Loading::ConcernStateCleaner
     subpath = @subpath_resolver.call(file_path)
 
     ObjectSpace.each_object(Module) do |mod|
-      next unless mod.singleton_class.ancestors.include?(ActiveSupport::Concern)
+      next unless SINGLETON_CLASS.bind_call(mod).ancestors.include?(ActiveSupport::Concern)
 
       clear_concern_ivars(mod, absolute, subpath)
     end
@@ -32,14 +48,14 @@ class Evilution::Integration::Loading::ConcernStateCleaner
 
   def clear_concern_ivars(mod, absolute, subpath)
     IVARS.each do |ivar|
-      next unless mod.instance_variable_defined?(ivar)
+      next unless IVAR_DEFINED.bind_call(mod, ivar)
 
-      block = mod.instance_variable_get(ivar)
+      block = IVAR_GET.bind_call(mod, ivar)
       block_file = block.source_location&.first
       next unless block_file
 
       expanded = File.expand_path(block_file)
-      mod.remove_instance_variable(ivar) if source_matches?(expanded, absolute, subpath)
+      REMOVE_IVAR.bind_call(mod, ivar) if source_matches?(expanded, absolute, subpath)
     end
   end
 

--- a/spec/evilution/integration/loading/concern_state_cleaner_spec.rb
+++ b/spec/evilution/integration/loading/concern_state_cleaner_spec.rb
@@ -32,6 +32,63 @@ RSpec.describe Evilution::Integration::Loading::ConcernStateCleaner do
     eval("proc {}", TOPLEVEL_BINDING, path, 1) # rubocop:disable Style/EvalWithLocation
   end
 
+  describe "modules that intercept method calls" do
+    # EV-v2rc / GH #1581: ActiveSupport::Deprecation::DeprecatedConstantProxy
+    # subclasses Module and undefines every instance method except __* and
+    # object_id, so ObjectSpace.each_object(Module) yields it and ANY message
+    # it receives lands in method_missing, which emits the deprecation. A
+    # project whose deprecator behaviour is :raise -- grape sets exactly that
+    # in its spec_helper -- turns our sweep into an exception. The sweep must
+    # therefore not send messages to the modules it walks.
+    def deprecation_proxy(touched)
+      klass = Class.new(Module) do
+        instance_methods.each { |m| undef_method(m) unless /^__|^object_id$/.match?(m) }
+
+        define_method(:method_missing) do |name, *_args|
+          touched << name
+          raise "deprecated constant touched via ##{name}"
+        end
+      end
+      klass.new
+    end
+
+    it "does not send messages to a module that intercepts them" do
+      touched = []
+      keep_alive = [deprecation_proxy(touched)]
+
+      Dir.mktmpdir("evilution_concern_proxy") do |dir|
+        target_path = File.join(dir, "concern.rb")
+        File.write(target_path, "")
+
+        expect { cleaner.call(target_path) }.not_to raise_error
+      end
+
+      expect(touched).to be_empty
+      expect(keep_alive.size).to eq(1)
+    end
+
+    it "still clears concern state while such a module is present" do
+      touched = []
+      keep_alive = [deprecation_proxy(touched)]
+
+      Dir.mktmpdir("evilution_concern_proxy_mixed") do |dir|
+        target_path = File.join(dir, "concern.rb")
+        File.write(target_path, "")
+
+        mod = Module.new
+        mod.extend(ActiveSupport::Concern)
+        mod.instance_variable_set(:@_included_block, block_at(target_path))
+
+        cleaner.call(target_path)
+
+        expect(mod.instance_variable_defined?(:@_included_block)).to be(false)
+      end
+
+      expect(touched).to be_empty
+      expect(keep_alive.size).to eq(1)
+    end
+  end
+
   describe "#initialize" do
     it "stores the default subpath resolver as a usable instance" do
       Dir.mktmpdir("evilution_concern_default") do |dir|


### PR DESCRIPTION
…: avoid sending messages to modules that intercept method calls and ensure concern state is cleared correctly.